### PR TITLE
Board support: DE1-SoC and zrtech_v2.00

### DIFF
--- a/blinky.core
+++ b/blinky.core
@@ -43,6 +43,11 @@ filesets:
       - upduino2/blinky_upduino2.v : {file_type : verilogSource}
       - upduino2/pinout.pcf : {file_type : PCF}
 
+  zrtech_v2:
+    files:
+      - zrtech_v2/zrtech_v2.sdc : {file_type : SDC}
+      - zrtech_v2/pinmap.tcl    : {file_type: tclSource}
+
 targets:
   default:
     filesets : [rtl]
@@ -144,6 +149,16 @@ targets:
         nextpnr_options : [--up5k]
         pnr: next
     toplevel : blinky_upduino2
+
+  zrtech_v2:
+    default_tool : quartus
+    filesets : [rtl, zrtech_v2]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : Cyclone IV E
+        device : EP4CE6E22C8
+    toplevel: blinky
 
 parameters:
   clk_freq_hz:

--- a/blinky.core
+++ b/blinky.core
@@ -12,6 +12,11 @@ filesets:
       - de0_nano/de0_nano.sdc : {file_type : SDC}
       - de0_nano/pinmap.tcl   : {file_type: tclSource}
 
+  de1_soc_revF:
+    files:
+      - de1_soc_revF/de1_soc_revF.sdc : {file_type : SDC}
+      - de1_soc_revF/pinmap.tcl       : {file_type : tclSource}
+
   lx9_microboard:
     files: [lx9_microboard/blinky.ucf : {file_type : UCF}]
 
@@ -72,6 +77,17 @@ targets:
       quartus:
         family : Cyclone IV E
         device : EP4CE22F17C6
+    toplevel: blinky
+
+  de1_soc_revF:
+    default_tool : quartus
+    filesets : [rtl, de1_soc_revF]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : Cyclone V
+        device : 5CSEMA5F31C6
+        board_device_index : 2
     toplevel: blinky
 
   lx9_microboard:

--- a/de1_soc_revF/de1_soc_revF.sdc
+++ b/de1_soc_revF/de1_soc_revF.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/de1_soc_revF/pinmap.tcl
+++ b/de1_soc_revF/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock
+#
+set_location_assignment PIN_AF14 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+#
+# LEDR0
+#
+set_location_assignment PIN_V16 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q

--- a/zrtech_v2/pinmap.tcl
+++ b/zrtech_v2/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock
+#
+set_location_assignment PIN_24 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+#
+# LED D2 (DS_DP)
+#
+set_location_assignment PIN_3 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q

--- a/zrtech_v2/zrtech_v2.sdc
+++ b/zrtech_v2/zrtech_v2.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty


### PR DESCRIPTION
This adds support for 2 of my FPGA dev-boards, namely the zrtech_v2.00 and the DE1-SoC.

Support for the DE1-SoC presently depends on the `board_device_index` option, the support for which is included in https://github.com/olofk/edalize/pull/53
