### PR TITLE
Add digilent Arty A7 35t support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ The following boards are currently supported
 
 http://www.armadeus.org/wiki/index.php?title=APF27
 
+### arty_a7_35t
+
+https://store.digilentinc.com/arty-a7-artix-7-fpga-development-board-for-makers-and-hobbyists/
+
 ### cyc1000
 
 https://shop.trenz-electronic.de/en/TEI0003-02-CYC1000-with-Cyclone-10-FPGA-8-MByte-SDRAM

--- a/arty_a7_35t/blinky.xdc
+++ b/arty_a7_35t/blinky.xdc
@@ -1,0 +1,6 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports { clk }]; #IO_L12P_T1_MRCC_35 Sch=gclk[100]
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports {clk}];
+
+## LED
+set_property -dict { PACKAGE_PIN H5   IOSTANDARD LVCMOS33 } [get_ports { q }]; #IO_L24N_T3_35 Sch=led[4]

--- a/blinky.core
+++ b/blinky.core
@@ -7,6 +7,9 @@ filesets:
       - apf27/blinky.ucf :  {file_type : UCF}
       - apf27/options.tcl : {file_type : tclSource}
 
+  arty_a7_35t:
+    files: [arty_a7_35t/blinky.xdc : {file_type : xdc}]
+
   cyc1000:
     files:
       - cyc1000/cyc1000.sdc : {file_type : SDC}
@@ -73,6 +76,15 @@ targets:
         device  : xc3s200a
         package : ft256
         speed   : -5
+    toplevel : blinky
+
+  arty_a7_35t:
+    default_tool : vivado
+    filesets : [rtl, arty_a7_35t]
+    parameters : [clk_freq_hz=100000000]
+    tools:
+      vivado:
+        part : xc7a35ticsg324-1L
     toplevel : blinky
 
   cyc1000:


### PR DESCRIPTION
Arty A7 Development board has two version 35T and 100T.
This patch adds support for 35T version.