### PR TITLE
Added few boards (pynq-z2, de10-soc, soc-kit, de0-nanosoc)

### DIFF
--- a/blinky.core
+++ b/blinky.core
@@ -25,6 +25,21 @@ filesets:
       - de0_nano/de0_nano.sdc : {file_type : SDC}
       - de0_nano/pinmap.tcl   : {file_type: tclSource}
 
+  de0_nanosoc:
+    files:
+      - de0_nanosoc/de0_nanosoc.sdc  : {file_type : SDC}
+      - de0_nanosoc/pinmap.tcl       : {file_type : tclSource}
+
+  de10_soc:
+    files:
+      - de10_soc/de10_soc.sdc : {file_type : SDC}
+      - de10_soc/pinmap.tcl  : {file_type : tclSource}
+
+  soc_kit:
+    files:
+      - soc_kit/soc_kit.sdc : {file_type : SDC}
+      - soc_kit/pinmap.tcl  : {file_type : tclSource}
+
   de1_soc_revF:
     files:
       - de1_soc_revF/de1_soc_revF.sdc : {file_type : SDC}
@@ -48,6 +63,11 @@ filesets:
 
   proginfo:
     files: [sw/proginfo.py : {file_type : user, copyto : proginfo.py}]
+
+  pynq_z2:
+    files:
+      - pynq_z2/blinky_pynq_z2.v : {file_type : verilogSource}
+      - pynq_z2/blinky.xdc : {file_type : xdc}
 
   tb:
     files: [blinky_tb.v : {file_type : verilogSource}]
@@ -133,6 +153,17 @@ targets:
         device : EP4CE22F17C6
     toplevel: blinky
 
+  de0_nanosoc:
+    default_tool : quartus
+    filesets : [rtl, de0_nanosoc]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : Cyclone V
+        device : 5CSEMA4U23C6
+        board_device_index : 2
+    toplevel: blinky
+
   de1_soc_revF:
     default_tool : quartus
     filesets : [rtl, de1_soc_revF]
@@ -142,6 +173,30 @@ targets:
         family : Cyclone V
         device : 5CSEMA5F31C6
         board_device_index : 2
+    toplevel: blinky
+
+  de10_soc:
+    default_tool : quartus
+    filesets : [rtl, de10_soc]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : Cyclone V
+        device : 5CSXFC6D6F31C6
+        cable : "DE-SoC"
+        board_device_index : 2
+    toplevel: blinky
+
+  soc_kit:
+    default_tool : quartus
+    filesets : [rtl, soc_kit]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : Cyclone V
+        device : 5CSXFC6D6F31C6
+        board_device_index : 2
+        cable : "USB-BlasterII"  # Is sufficient
     toplevel: blinky
 
   ice40-hx8k_breakout:
@@ -195,6 +250,15 @@ targets:
         package : csg225
         speed   : -2
     toplevel : blinky
+
+  pynq_z2:
+    default_tool: vivado
+    description : Pynq-Z2 Zynq Z7020 Evaluation Kit
+    filesets : [rtl, pynq_z2]
+    tools:
+      vivado:
+        part : xc7z020clg400-1
+    toplevel : blinky_pynq_z2
 
   sim:
     default_tool: icarus

--- a/de0_nanosoc/de0_nanosoc.sdc
+++ b/de0_nanosoc/de0_nanosoc.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/de0_nanosoc/pinmap.tcl
+++ b/de0_nanosoc/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock
+#
+set_location_assignment PIN_V11 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+#
+# LEDR0
+#
+set_location_assignment PIN_W15 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q

--- a/de10_soc/de10_soc.sdc
+++ b/de10_soc/de10_soc.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/de10_soc/pinmap.tcl
+++ b/de10_soc/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock
+#
+set_location_assignment PIN_AF14 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+#
+# LEDR0
+#
+set_location_assignment PIN_AA24 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q

--- a/pynq_z2/blinky.xdc
+++ b/pynq_z2/blinky.xdc
@@ -1,0 +1,6 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN H16 IOSTANDARD LVCMOS33 } [get_ports clk];
+create_clock -add -name sys_clk_pin -period 8 -waveforem {0 4} [get_nets clk];
+
+## LED
+set_property -dict { PACKAGE_PIN R14 IOSTANDARD LVCMOS33 } [get_ports q];

--- a/pynq_z2/blinky_pynq_z2.v
+++ b/pynq_z2/blinky_pynq_z2.v
@@ -1,0 +1,11 @@
+module blinky_pynq_z2
+  (input wire  clk,
+   output wire q);
+
+   wire        clk;
+
+   blinky #(.clk_freq_hz (125_000_000)) blinky
+     (.clk (clk),
+      .q   (q));
+
+endmodule

--- a/soc_kit/pinmap.tcl
+++ b/soc_kit/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock
+#
+set_location_assignment PIN_AC18 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+#
+# LEDR0
+#
+set_location_assignment PIN_AK2 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q

--- a/soc_kit/soc_kit.sdc
+++ b/soc_kit/soc_kit.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty


### PR DESCRIPTION
(of which last is untested, due to broken usb-jtag.)

Boards were tested, also using the cable option in edalize. So that dependency exists.
