### PR TITLE
Add KCU1500 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ http://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/iCE40HX8KBreakou
 
 https://www.avnet.com/shop/us/products/avnet-engineering-services/aes-s6mb-lx9-g-3074457345628965461/
 
+### kcu1500
+
+https://www.xilinx.com/products/boards-and-kits/dk-u1-kcu1500-g.html
+
 ### machXO2_breakout
 
 https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/MachXO2BreakoutBoard

--- a/blinky.core
+++ b/blinky.core
@@ -68,6 +68,11 @@ filesets:
   lx9_microboard:
     files: [lx9_microboard/blinky.ucf : {file_type : UCF}]
 
+  kcu1500:
+    files:
+      - kcu1500/blinky_kcu1500.v : {file_type : verilogSource}
+      - kcu1500/blinky.xdc : {file_type : xdc}
+
   machXO2_breakout:
     files:
       - machXO2_breakout/blinky.lpf : {file_type : LPF}
@@ -322,6 +327,15 @@ targets:
         package : csg324
         speed   : -2
     toplevel : blinky
+
+  kcu1500:
+    default_tool: vivado
+    description : Kintex UltraScale KCU1500 Acceleration Development Kit
+    filesets : [rtl, kcu1500]
+    tools:
+      vivado:
+        part : xcku115-flvb2104-2-e
+    toplevel : blinky_kcu1500
 
   machXO2_breakout:
     default_tool : diamond

--- a/kcu1500/blinky.xdc
+++ b/kcu1500/blinky.xdc
@@ -1,0 +1,12 @@
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+set_property BITSTREAM.CONFIG.CONFIGRATE 50 [current_design]
+set_property CONFIG_VOLTAGE 1.8 [current_design]
+set_property CFGBVS GND [current_design]
+
+## LED
+set_property -dict { PACKAGE_PIN AW25 IOSTANDARD LVCMOS18 } [get_ports q]
+
+set_property -dict { PACKAGE_PIN BA34 IOSTANDARD DIFF_SSTL12 } [get_ports sys_clk_p];
+set_property -dict { PACKAGE_PIN BB34 IOSTANDARD DIFF_SSTL12 } [get_ports sys_clk_n];
+
+create_clock -name sys_clk -period 3.33 [get_ports sys_clk_p]

--- a/kcu1500/blinky_kcu1500.v
+++ b/kcu1500/blinky_kcu1500.v
@@ -1,0 +1,22 @@
+module blinky_kcu1500 (
+  input wire  sys_clk_p,
+  input wire  sys_clk_n,
+  output wire q
+);
+
+  wire clk;
+  IBUFDS ibufds
+  (
+    .I  (sys_clk_p),
+    .IB (sys_clk_n),
+    .O  (clk)
+  );
+
+  blinky #(
+    .clk_freq_hz(300_300_300)
+  ) blinky (
+    .clk (clk),
+    .q   (q)
+  );
+
+endmodule


### PR DESCRIPTION
This adds minimal blinky support for the KCU1500 board, it uses one
of the 300 MHz clock inputs to generate a blinking led.

Signed-off-by: Moritz Fischer <mdf@kernel.org>