### PR TITLE
apf51: adding the armadeus board apf51dev with spartan6

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ https://www.arrow.com/en/products/tei0001-03-16-c8/trenz-electronic-gmbh
 
 http://www.armadeus.org/wiki/index.php?title=APF27
 
+### afp51
+
+http://www.armadeus.org/wiki/index.php?title=APF51
+
 ### Alhambra II
 
 https://alhambrabits.com/alhambra/

--- a/apf51/blinky.ucf
+++ b/apf51/blinky.ucf
@@ -1,0 +1,7 @@
+# Clock at 92.85MHz
+NET "Clk" LOC = "N8"; # EIM_BCLK
+NET "Clk" TNM_NET = "Clk";
+TIMESPEC "TS_Clk" = PERIOD "Clk" 10.77 ns HIGH 50 %;
+
+# LED
+NET "q" LOC = "G14"| IOSTANDARD = LVCMOS33 ; #IO_L41P_GCLK9

--- a/apf51/options.tcl
+++ b/apf51/options.tcl
@@ -1,0 +1,1 @@
+project set "Create Binary Configuration File" "true" -process "Generate Programming File"

--- a/blinky.core
+++ b/blinky.core
@@ -15,6 +15,11 @@ filesets:
       - apf27/blinky.ucf :  {file_type : UCF}
       - apf27/options.tcl : {file_type : tclSource}
 
+  apf51:
+    files: 
+      - apf51/blinky.ucf : {file_type : UCF}
+      - apf51/options.tcl : {file_type : tclSource}
+
   arty_a7_35t:
     files: [arty_a7_35t/blinky.xdc : {file_type : xdc}]
 
@@ -195,6 +200,18 @@ targets:
         device  : xc3s200a
         package : ft256
         speed   : -5
+    toplevel : blinky
+
+  apf51:
+    default_tool : ise
+    filesets : [rtl, apf51]
+    parameters : [clk_freq_hz=92850000]
+    tools:
+      ise:
+        family  : Spartan6
+        device  : xc6slx9
+        package : csg225
+        speed   : -2
     toplevel : blinky
 
   arty_a7_35t:


### PR DESCRIPTION
An integration of APF51 board on [apf51dev](http://www.opossom.com/english/products-development_boards-apf51_dev.html). Some explains are given on [armadeus wiki](http://www.armadeus.org/wiki/index.php?title=FuseSoC#APF51).

The fpga is configured under U-Boot and need a binary format (*.bin) instead of traditionnal bitstream (*.bit). It's the reason of tcl file -> force generation of binary *.bin