### PR TITLE
add crosslink_nx_evn support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ https://store.digilentinc.com/arty-a7-artix-7-fpga-development-board-for-makers-
 
 https://fr.aliexpress.com/item/32281130824.html
 
+### crosslink_nx_evn
+
+https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/CrossLink-NXEvaluationBoard
+
 ### cyc1000
 
 https://shop.trenz-electronic.de/en/TEI0003-02-CYC1000-with-Cyclone-10-FPGA-8-MByte-SDRAM

--- a/blinky.core
+++ b/blinky.core
@@ -21,6 +21,9 @@ filesets:
   colorlight_5a75b:
     files: [colorlight_5a75b/blinky.lpf : {file_type : LPF}]
 
+  crosslink_nx_evn:
+    files: [crosslink_nx_evn/blinky.pdc : {file_type : PDC}]
+
   cyc1000:
     files:
       - cyc1000/cyc1000.sdc : {file_type : SDC}
@@ -213,6 +216,15 @@ targets:
     tools:
       trellis:
         nextpnr_options : [--25k --package CABGA256 --speed 6 --freq 65]
+    toplevel : blinky
+
+  crosslink_nx_evn:
+    default_tool : radiant
+    description : CrossLink NX Evaluation Board
+    filesets : [rtl, crosslink_nx_evn]
+    parameters : [clk_freq_hz=12000000]
+    tools:
+      radiant : {part: LIFCL-40-9BG400C}
     toplevel : blinky
 
   cyc1000:

--- a/crosslink_nx_evn/blinky.pdc
+++ b/crosslink_nx_evn/blinky.pdc
@@ -1,0 +1,6 @@
+ldc_set_location -site {L13} [get_ports clk]
+ldc_set_port -iobuf {IO_TYPE=LVCMOS33 PULLMODE=NONE} [get_ports clk]
+ldc_set_location -site {E17} [get_ports q]
+ldc_set_port -iobuf {IO_TYPE=LVCMOS33} [get_ports q]
+
+ldc_set_sysconfig {CONFIG_MODE=SPI_SERIAL MCCLK_FREQ=3.5}


### PR DESCRIPTION
the crosslink nx Evaluation board is based on LIFCL-40-9BG400C
This PR depends on https://github.com/olofk/edalize/pull/192