### PR TITLE
Add support for Microsemi Polarfire FPGA

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ https://www.latticesemi.com/products/developmentboardsandkits/machxo3lfstarterki
 
 https://shop.trenz-electronic.de/en/TEI0001-03-08-C8-MAX1000-IoT-Maker-Board-8KLE-8-MByte-RAM
 
+### Microsemi Polarfire Evaluation Kit
+
+https://www.microsemi.com/existing-parts/parts/150789
+
 ### nexys_a7
 
 https://store.digilentinc.com/nexys-a7-fpga-trainer-board-recommended-for-ece-curriculum

--- a/blinky.core
+++ b/blinky.core
@@ -191,6 +191,11 @@ filesets:
       - zybo_z7/blinky_zybo_z7.v : {file_type : verilogSource}
       - zybo_z7/blinky.xdc : {file_type : xdc}
 
+  polarfireeval:
+    files:
+      - polarfireeval/blinky_polarfireeval.v : {file_type : verilogSource}
+      - polarfireeval/polarfireeval.pdc : {file_type : PDC}
+
 targets:
   default: &default
     filesets : [rtl]
@@ -670,6 +675,24 @@ targets:
     tools:
       vivado:
         part : xc7z020clg400-1
+
+  polarfireeval: &polarfireeval
+    default_tool: libero
+    description : Microsemi Polarfire Evaluation Kit
+    filesets : [rtl, polarfireeval]
+    tools:
+      libero:
+        family : Polarfire
+        die : MPF300TS
+        package : FCG1152
+    toplevel : blinky_polarfireeval
+
+  polarfireeval_es:
+    <<: *polarfireeval
+    description : Microsemi Polarfire Evaluation Kit (ES)
+    tools:
+      libero:
+        die : MPF300TS_ES
 
 parameters:
   clk_freq_hz:

--- a/blinky.core
+++ b/blinky.core
@@ -681,8 +681,8 @@ targets:
     description : Microsemi Polarfire Evaluation Kit
     filesets : [rtl, polarfireeval]
     tools:
-      libero:
-        family : Polarfire
+      libero: &liberoMPF300
+        family : PolarFire
         die : MPF300TS
         package : FCG1152
     toplevel : blinky_polarfireeval
@@ -692,6 +692,7 @@ targets:
     description : Microsemi Polarfire Evaluation Kit (ES)
     tools:
       libero:
+        <<: *liberoMPF300
         die : MPF300TS_ES
 
 parameters:

--- a/polarfireeval/blinky_polarfireeval.v
+++ b/polarfireeval/blinky_polarfireeval.v
@@ -1,0 +1,9 @@
+module blinky_polarfireeval
+  (input wire 	    clk,
+   output wire 	    q);
+
+   blinky #(.clk_freq_hz (50_000_000)) blinky
+     (.clk (clk),
+      .q   (q));
+
+endmodule

--- a/polarfireeval/polarfireeval.pdc
+++ b/polarfireeval/polarfireeval.pdc
@@ -1,0 +1,2 @@
+set_io -port_name {clk} -pin_name E25 -io_std LVCMOS18 -fixed true
+set_io -port_name {q} -pin_name F22 -io_std LVCMOS18 -fixed true


### PR DESCRIPTION
Add support for Microsemi Polarfire FPGA. This is still a WIP for review.

This PR depends on Libero support added to Edalize on https://github.com/olofk/edalize/pull/212.