### PR TITLE
Add support for Waveshare CoreEP4CE10

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ https://shop.trenz-electronic.de/en/TEI0003-02-CYC1000-with-Cyclone-10-FPGA-8-MB
 
 https://https://github.com/tomverbeure/cisco-hwic-3g-cdma
 
+## Waveshare CoreEP4CE10
+
+https://www.waveshare.com/wiki/CoreEP4CE10
+
 ### de0_nano
 
 https://www.terasic.com.tw/cgi-bin/page/archive.pl?No=593

--- a/blinky.core
+++ b/blinky.core
@@ -50,6 +50,11 @@ filesets:
       - cisco-hwic-3g-cdma/cisco-hwic-3g-cdma.sdc : {file_type : SDC}
       - cisco-hwic-3g-cdma/pinmap.tcl  : {file_type: tclSource}
 
+  core_ep4ce10:
+    files:
+      - core_ep4ce10/core_ep4ce10.sdc : {file_type : SDC}
+      - core_ep4ce10/pinmap.tcl   : {file_type: tclSource}
+
   sockit:
     files:
       - sockit/sockit.sdc : {file_type : SDC}
@@ -342,6 +347,16 @@ targets:
       quartus:
         family : Cyclone II
         device : EP2C35F484C8
+
+  core_ep4ce10:
+    default_tool : quartus
+    filesets : [rtl, core_ep4ce10]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : Cyclone IV E
+        device : EP4CE10F17C8
+    toplevel: blinky
 
   sockit:
     default_tool : quartus

--- a/core_ep4ce10/core_ep4ce10.sdc
+++ b/core_ep4ce10/core_ep4ce10.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/core_ep4ce10/pinmap.tcl
+++ b/core_ep4ce10/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock / Reset
+#
+set_location_assignment PIN_E16 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+#
+# GPIO0
+#
+set_location_assignment PIN_D12 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q


### PR DESCRIPTION
Add support for https://www.waveshare.com/wiki/CoreEP4CE10 code is based on de0_nano (except for pins).