### PR TITLE
Added support for Nexys4 Devboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ https://shop.trenz-electronic.de/en/TEI0001-03-08-C8-MAX1000-IoT-Maker-Board-8KL
 
 https://www.microsemi.com/existing-parts/parts/150789
 
+### nexys_4
+
+https://reference.digilentinc.com/reference/programmable-logic/nexys-4/start
+
 ### nexys_a7
 
 https://store.digilentinc.com/nexys-a7-fpga-trainer-board-recommended-for-ece-curriculum

--- a/blinky.core
+++ b/blinky.core
@@ -152,6 +152,8 @@ filesets:
 
   mini_s7: {files: [mini_s7/blinky.xdc : {file_type : xdc}]}
 
+  nexys_4: {files: [nexys_4/blinky.xdc : {file_type : xdc}]}
+
   nexys_a7: {files: [nexys_a7/blinky.xdc : {file_type : xdc}]}
 
   nexys_video: {files: [nexys_video/blinky.xdc : {file_type : xdc}]}
@@ -612,6 +614,15 @@ targets:
     tools:
       vivado:
         part : xc7s25ftgb196-1
+    toplevel : blinky
+
+  nexys_4:
+    default_tool: vivado
+    filesets : [rtl, nexys_4]
+    parameters : [clk_freq_hz=100000000]
+    tools:
+      vivado:
+        part : xc7a100tcsg324-1
     toplevel : blinky
 
   nexys_a7:

--- a/nexys_4/blinky.xdc
+++ b/nexys_4/blinky.xdc
@@ -1,0 +1,11 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN E3 IOSTANDARD LVCMOS33 } [get_ports { clk }]; #IO_L12P_T1_MRCC_34 Sch=CLK100MHZ
+create_clock -add -name sys_clk_pin -period 10.000 -waveform {0 5.000}  [get_ports { clk }];
+
+## LED
+set_property -dict { PACKAGE_PIN T8 IOSTANDARD LVCMOS33 } [get_ports { q }]; #IO_L23N_T3_A02_D18_14 Sch=led[0]
+
+
+## Configuration options, can be used for all designs
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]


### PR DESCRIPTION
Added support for Nexys4 devboard, specifically the right-most LED.
This FPGA is the same as the Nexys A7 but on a different board.