### PR TITLE
Add support for Cyclone 10 LP Refkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ https://store.digilentinc.com/arty-a7-artix-7-fpga-development-board-for-makers-
 
 https://store.digilentinc.com/basys-3-artix-7-fpga-beginner-board-recommended-for-introductory-users/
 
+### c10lp_refkit
+
+https://shop.trenz-electronic.de/en/TEI0009-02-055-8CA-Cyclone-10-LP-RefKit-10CL055-Development-Board-32-MByte-SDRAM-16-MByte-Flash
+
 ### colorlight_5a75b
 
 https://fr.aliexpress.com/item/32281130824.html

--- a/blinky.core
+++ b/blinky.core
@@ -37,6 +37,11 @@ filesets:
   basys3:
     files: [basys3/blinky.xdc : {file_type : xdc}]
 
+  c10lp_refkit:
+    files:
+      - c10lp_refkit/c10lp_refkit.sdc : {file_type: SDC}
+      - c10lp_refkit/pinmap.tcl       : {file_type: tclSource}
+
   colorlight_5a75b:
     files: [colorlight_5a75b/blinky.lpf : {file_type : LPF}]
 
@@ -329,6 +334,17 @@ targets:
       vivado:
         part : xc7a35tcpg236-1
     toplevel : blinky
+
+  c10lp_refkit:
+    <<: *default
+    default_tool : quartus
+    description : Cyclone 10 LP RefKit 10CL055 Development Board
+    filesets_append : [c10lp_refkit]
+    parameters : [clk_freq_hz=25000000]
+    tools:
+      quartus:
+        family : Cyclone 10 LP
+        device : 10CL055YU484C8G
 
   colorlight_5a75b:
     default_tool : trellis

--- a/c10lp_refkit/c10lp_refkit.sdc
+++ b/c10lp_refkit/c10lp_refkit.sdc
@@ -1,0 +1,8 @@
+# Use 25MHz U22 as main clock
+create_clock -name "clk" -period 40.00ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/c10lp_refkit/pinmap.tcl
+++ b/c10lp_refkit/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock / Reset
+#
+set_location_assignment PIN_AA12 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to clk
+
+#
+# GPIO0
+#
+set_location_assignment PIN_D18 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q


### PR DESCRIPTION
The full name is quite long, so i did as litex did and called it ```c10lp_refkit```.

Seems to work fine:
```$ fusesoc run --target c10lp_refkit fusesoc:utils:blinky --cable "Arrow-USB-Blaster [AR3M3WMU]"```
![output](https://user-images.githubusercontent.com/7694551/112688007-8c89e880-8e78-11eb-97dd-f37ceb59a65a.gif)
