### PR TITLE
Add support for SparkFun Alchitry Au board

### DIFF
--- a/alchitry_au/blinky.xdc
+++ b/alchitry_au/blinky.xdc
@@ -1,0 +1,10 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN N14 IOSTANDARD LVCMOS33 } [get_ports { clk }];
+create_clock -name clk -period 10.000 -waveform {0.000 5.000} [get_ports { clk }]
+
+## LED
+set_property -dict { PACKAGE_PIN K13 IOSTANDARD LVCMOS33 } [get_ports { q }];
+
+## Configuration options, can be used for all designs
+set_property CONFIG_VOLTAGE 3.3 [current_design]
+set_property CFGBVS VCCO [current_design]

--- a/blinky.core
+++ b/blinky.core
@@ -7,6 +7,10 @@ filesets:
       - ac701/blinky_ac701.v : {file_type : verilogSource}
       - ac701/blinky.xdc : {file_type : xdc}
 
+  alchitry_au:
+    files:
+      - alchitry_au/blinky.xdc : {file_type : xdc}
+
   alhambra_II:
     files: [alhambra_II/pinout.pcf : {file_type : PCF}]
 
@@ -269,6 +273,16 @@ targets:
       vivado:
         part : xc7a200t-fbg676-2
     toplevel : blinky_ac701
+
+  alchitry_au:
+    default_tool: vivado
+    description : SparkFun Alchitry Au, 100 MHz Xilinx Artix-7 with 256MB DDR3 RAM
+    filesets: [rtl, alchitry_au]
+    parameters: [clk_freq_hz=100000000]
+    tools:
+      vivado:
+        part: xc7a35tftg256-1
+    toplevel: blinky
 
   alhambra_II:
     default_tool : icestorm


### PR DESCRIPTION
Mostly a copy of the Basys3 setup with different pin assignments matching the Alchitry Au board. Tested on a Alchitry Au board with Vivado v2020.2 (64-bit).