### PR TITLE
Add support for Terasic DE10 Nano Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ https://www.terasic.com.tw/cgi-bin/page/archive.pl?No=593
 
 https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=165&No=836
 
+### de10_nano
+
+https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=205&No=1046
+
 ### DECA
 
 https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=&No=944&PartNo=1

--- a/blinky.core
+++ b/blinky.core
@@ -95,6 +95,11 @@ filesets:
       - de5_net/de5_net.sdc : {file_type : SDC}
       - de5_net/pinmap.tcl  : {file_type: tclSource}
 
+  de10_nano:
+    files:
+      - de10_nano/de10_nano.sdc : {file_type : SDC}
+      - de10_nano/pinmap.tcl  : {file_type : tclSource}
+
   de10_soc:
     files:
       - de10_soc/de10_soc.sdc : {file_type : SDC}
@@ -492,6 +497,18 @@ targets:
       quartus:
         family : Cyclone V
         device : 5CSEMA5F31C6
+        board_device_index : 2
+    toplevel: blinky
+
+  de10_nano:
+    default_tool : quartus
+	description : Terasic DE10 Nano Kit
+    filesets : [rtl, de10_nano]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : Cyclone V
+        device : 5CSEBA6U23I7
         board_device_index : 2
     toplevel: blinky
 

--- a/de10_nano/de10_nano.sdc
+++ b/de10_nano/de10_nano.sdc
@@ -1,0 +1,8 @@
+# Main system clock (50 Mhz)
+create_clock -name "clk" -period 20.000ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/de10_nano/pinmap.tcl
+++ b/de10_nano/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock
+#
+set_location_assignment PIN_V11 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+#
+# LEDR0
+#
+set_location_assignment PIN_W15 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q


### PR DESCRIPTION
Terasic DE10 Nano kit is a cycloneV SoC (5CSEBA6U23I7) based board