### PR TITLE
Add Nandland Go Board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ https://tomu.im/fomu.html
 
 https://repo.or.cz/fpc-iii.git
 
+### Nandland Go Board
+
+https://www.nandland.com/goboard/introduction.html
+
 ### ice40hx1k_evb
 
 https://www.olimex.com/wiki/ICE40HX1K-EVB

--- a/blinky.core
+++ b/blinky.core
@@ -126,6 +126,11 @@ filesets:
       - genesys2/blinky.xdc : {file_type : xdc}
       - genesys2/blinky_genesys2.v : {file_type : verilogSource}
 
+  go_board:
+    files:
+      - go_board/pinout.pcf : {file_type : PCF}
+      - go_board/blinky_go_board.v : {file_type : verilogSource}
+  
   ice40hx1k_evb:
     files: [ice40hx1k_evb/pinout.pcf : {file_type : PCF}]
 
@@ -574,6 +579,16 @@ targets:
         board_device_index : 2
         cable : "USB-BlasterII"  # Is sufficient
     toplevel: blinky
+
+  go_board:
+    default_tool : icestorm
+    filesets : [proginfo, go_board]
+    parameters : [clk_freq_hz=20000000]
+    tools:
+      icestorm:
+        nextpnr_options : [--hx1k, --package, vq100]
+        pnr : next
+    toplevel : blinky_go_board
 
   ice40hx1k_evb:
     default_tool : icestorm

--- a/go_board/blinky_go_board.v
+++ b/go_board/blinky_go_board.v
@@ -1,0 +1,19 @@
+module blinky_go_board
+  #(parameter clk_freq_hz = 0)
+   (input  clk,
+    output reg q = 1'b0,
+    output led2 = 1'b0,
+    output led3 = 1'b0,
+    output led4 = 1'b0);
+
+   reg [$clog2(clk_freq_hz)-1:0] count = 0;
+
+   always @(posedge clk) begin
+      count <= count + 1;
+      if (count == clk_freq_hz-1) begin
+	 q <= !q;
+	 count <= 0;
+      end
+   end
+
+endmodule

--- a/go_board/pinout.pcf
+++ b/go_board/pinout.pcf
@@ -1,0 +1,5 @@
+set_io clk 15
+set_io q 56
+set_io led2 57
+set_io led3 59
+set_io led4 60


### PR DESCRIPTION
Here's support for the Nandland Go Board:

  https://www.nandland.com/goboard/introduction.html

I created its own Verilog file because the board has 4 LEDs, and they are on by default unless explicitly turned off.