### PR TITLE
Correct Go Board clock frequency to 25MHz

### DIFF
--- a/blinky.core
+++ b/blinky.core
@@ -583,7 +583,7 @@ targets:
   go_board:
     default_tool : icestorm
     filesets : [proginfo, go_board]
-    parameters : [clk_freq_hz=20000000]
+    parameters : [clk_freq_hz=25000000]
     tools:
       icestorm:
         nextpnr_options : [--hx1k, --package, vq100]

--- a/go_board/blinky_go_board.v
+++ b/go_board/blinky_go_board.v
@@ -1,18 +1,19 @@
 module blinky_go_board
   #(parameter clk_freq_hz = 0)
-   (input  clk,
-    output reg q = 1'b0,
-    output led2 = 1'b0,
-    output led3 = 1'b0,
-    output led4 = 1'b0);
+   (input      clk,
+    output reg led1 = 1'b0,
+    // Prevent the other three LEDs from floating
+    output     led2 = 1'b0,
+    output     led3 = 1'b0,
+    output     led4 = 1'b0);
 
    reg [$clog2(clk_freq_hz)-1:0] count = 0;
 
    always @(posedge clk) begin
       count <= count + 1;
       if (count == clk_freq_hz-1) begin
-	 q <= !q;
-	 count <= 0;
+         led1 <= !led1;
+         count <= 0;
       end
    end
 

--- a/go_board/pinout.pcf
+++ b/go_board/pinout.pcf
@@ -1,5 +1,5 @@
 set_io clk 15
-set_io q 56
+set_io led1 56
 set_io led2 57
 set_io led3 59
 set_io led4 60


### PR DESCRIPTION
Make all LED output names consistent in the RTL and  PCF.