### PR TITLE
Add support for EBAZ4205 'Development' Board

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,19 @@ https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=2
 
 https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&CategoryNo=&No=944&PartNo=1
 
+### EBAZ4205 'Development' Board
+
+This development board featuring `Zynq 7010` was the control card of Ebit E9+
+BTC miner.
+
+Note: The Zynq PL on this board doesn't have a reference clock without
+involving the Zynq PS. To workaround this problem, the onboard 33MHz clock
+oscillator can be physically bridged to the PL clock input pin. To do this,
+solder a fine wire from R2340 (the clock output of X8) to the PL clock input on
+the pad for the missing R1372 near X5.
+
+https://github.com/xjtuecho/EBAZ4205
+
 ### ecp5_evn
 
 https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/ECP5EvaluationBoard

--- a/blinky.core
+++ b/blinky.core
@@ -257,6 +257,11 @@ filesets:
       - zybo_z7/blinky_zybo_z7.v : {file_type : verilogSource}
       - zybo_z7/blinky.xdc : {file_type : xdc}
 
+  ebaz4205:
+    files:
+      - ebaz4205/blinky_ebaz4205.v : {file_type : verilogSource}
+      - ebaz4205/combined.xdc : {file_type : xdc}
+
   polarfireeval:
     files:
       - polarfireeval/blinky_polarfireeval.v : {file_type : verilogSource}
@@ -908,6 +913,15 @@ targets:
         family : Cyclone IV E
         device : EP4CE6E22C8
     toplevel: blinky
+
+  ebaz4205: &ebaz4205
+    default_tool: vivado
+    description : EBAZ4205 'Development' Board
+    filesets : [rtl, ebaz4205]
+    tools:
+      vivado:
+        part : xc7z010clg400-1
+    toplevel : blinky_ebaz4205
 
   zybo_z7-10: &zybo_z7
     default_tool: vivado

--- a/ebaz4205/blinky_ebaz4205.v
+++ b/ebaz4205/blinky_ebaz4205.v
@@ -1,0 +1,11 @@
+module blinky_ebaz4205
+  (input wire  clk,
+   output wire q);
+
+   wire        clk;
+
+   blinky #(.clk_freq_hz (33_333_000)) blinky
+     (.clk (clk),
+      .q   (q));
+
+endmodule

--- a/ebaz4205/combined.xdc
+++ b/ebaz4205/combined.xdc
@@ -1,0 +1,7 @@
+## 33.333 MHz Clock signal
+set_property -dict { PACKAGE_PIN N18 IOSTANDARD LVCMOS33 } [get_ports { clk }];
+create_clock -add -name sys_clk_pin -period 30.00 -waveform {0 4} [get_ports { clk }];
+
+## LED(s)
+# set_property -dict { PACKAGE_PIN W13 IOSTANDARD LVCMOS33 } [get_ports { q_green }];
+set_property -dict { PACKAGE_PIN W14 IOSTANDARD LVCMOS33 } [get_ports { q }];


### PR DESCRIPTION
This PR adds support for the EBAZ4205 'Development' Board.

References:

- https://github.com/xjtuecho/EBAZ4205 (has schematics)
- https://github.com/embed-me/ebaz4205_fpga
- The existing 'zybo_z7' board configuration

Usage:

```
fusesoc run --target=ebaz4205 fusesoc:utils:blinky
```

Tested with: Vivado 2021.1 running on Xubuntu 21.04

Notes:

The Zynq PL on this board doesn't have a reference clock without involving the Zynq PS.

To workaround this problem, the onboard 33MHz clock oscillator can be physically bridged to the PL clock input pin. To do this, solder a fine wire from R2340 (the clock output of X8) to the PL clock input on the pad for the missing R1372 near X5.

Credits: David Richards + the `EBAZ4205` group on Telegram.