### PR TITLE
add ultra96_v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ https://tangnano.sipeed.com/en/
 
 https://www.crowdsupply.com/tinyfpga/tinyfpga-bx
 
+### ultra96_v2
+
+https://www.avnet.com/wps/portal/us/products/avnet-boards/avnet-board-families/ultra96-v2/
+
+Note: There is no on-board clock for Zynq PL. Therefore, in this example PL clock is generated and supplied from
+Zynq PS in the block design. Block design tcl script is generated on Vivado 2020.2. If you have an other version
+of Vivado installation, you should just create and export the block design bd_ultra96_v2.tcl with fabric clock
+PL0 is enabled and made external.
+
 ### ulx3s_*
 
 https://radiona.org/ulx3s
@@ -248,7 +257,7 @@ http://www.hseda.com/product/xilinx/XC6SLX9COREV1.0/XC6SLX9CORE.htm
 ### zcu102
 
 https://www.xilinx.com/products/boards-and-kits/zcu102.html
-
+1
 ### zcu106
 
 https://www.xilinx.com/products/boards-and-kits/zcu106.html

--- a/blinky.core
+++ b/blinky.core
@@ -223,6 +223,13 @@ filesets:
 
   tinyfpga_bx:
     files: [tinyfpga_bx/pinout.pcf : {file_type : PCF}]
+  
+  ultra96_v2:
+    files:
+      - ultra96_v2/blinky_ultra96_v2.v : {file_type : verilogSource}
+      - ultra96_v2/design_1_wrapper.v : {file_type : verilogSource}  
+      - ultra96_v2/blinky.xdc : {file_type : xdc}
+      - ultra96_v2/bd_ultra96_v2.tcl : {file_type : tclSource}
 
   ulx3s:
     files:
@@ -842,6 +849,15 @@ targets:
         nextpnr_options : [--lp8k, --package, cm81]
         pnr: next
     toplevel : blinky
+
+  ultra96_v2:
+    default_tool : vivado
+    description : Zynq UltraScale+ MPSoC Ultra96-v2 Development Board 
+    filesets : [rtl, ultra96_v2]
+    tools:
+      vivado:
+        part : xczu3eg-sbva484-1-i
+    toplevel : blinky_ultra96_v2
 
   ulx3s_45: &ulx3s
     default_tool : trellis

--- a/ultra96_v2/bd_ultra96_v2.tcl
+++ b/ultra96_v2/bd_ultra96_v2.tcl
@@ -1,0 +1,932 @@
+
+################################################################
+# This is a generated script based on design: design_1
+#
+# Though there are limitations about the generated script,
+# the main purpose of this utility is to make learning
+# IP Integrator Tcl commands easier.
+################################################################
+
+namespace eval _tcl {
+proc get_script_folder {} {
+   set script_path [file normalize [info script]]
+   set script_folder [file dirname $script_path]
+   return $script_folder
+}
+}
+variable script_folder
+set script_folder [_tcl::get_script_folder]
+
+################################################################
+# Check if script is running in correct Vivado version.
+################################################################
+set scripts_vivado_version 2020.2
+set current_vivado_version [version -short]
+
+if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
+   puts ""
+   catch {common::send_gid_msg -ssname BD::TCL -id 2041 -severity "ERROR" "This script was generated using Vivado <$scripts_vivado_version> and is being run in <$current_vivado_version> of Vivado. Please run the script in Vivado <$scripts_vivado_version> then open the design in Vivado <$current_vivado_version>. Upgrade the design by running \"Tools => Report => Report IP Status...\", then run write_bd_tcl to create an updated script."}
+
+   return 1
+}
+
+################################################################
+# START
+################################################################
+
+# To test this script, run the following commands from Vivado Tcl console:
+# source design_1_script.tcl
+
+# If there is no project opened, this script will create a
+# project, but make sure you do not have an existing project
+# <./myproj/project_1.xpr> in the current working folder.
+
+set list_projs [get_projects -quiet]
+if { $list_projs eq "" } {
+   create_project project_1 myproj -part xczu3eg-sbva484-1-i
+   set_property BOARD_PART avnet.com:ultra96v2:part0:1.2 [current_project]
+}
+
+
+# CHANGE DESIGN NAME HERE
+variable design_name
+set design_name design_1
+
+# If you do not already have an existing IP Integrator design open,
+# you can create a design using the following command:
+#    create_bd_design $design_name
+
+# Creating design if needed
+set errMsg ""
+set nRet 0
+
+set cur_design [current_bd_design -quiet]
+set list_cells [get_bd_cells -quiet]
+
+if { ${design_name} eq "" } {
+   # USE CASES:
+   #    1) Design_name not set
+
+   set errMsg "Please set the variable <design_name> to a non-empty value."
+   set nRet 1
+
+} elseif { ${cur_design} ne "" && ${list_cells} eq "" } {
+   # USE CASES:
+   #    2): Current design opened AND is empty AND names same.
+   #    3): Current design opened AND is empty AND names diff; design_name NOT in project.
+   #    4): Current design opened AND is empty AND names diff; design_name exists in project.
+
+   if { $cur_design ne $design_name } {
+      common::send_gid_msg -ssname BD::TCL -id 2001 -severity "INFO" "Changing value of <design_name> from <$design_name> to <$cur_design> since current design is empty."
+      set design_name [get_property NAME $cur_design]
+   }
+   common::send_gid_msg -ssname BD::TCL -id 2002 -severity "INFO" "Constructing design in IPI design <$cur_design>..."
+
+} elseif { ${cur_design} ne "" && $list_cells ne "" && $cur_design eq $design_name } {
+   # USE CASES:
+   #    5) Current design opened AND has components AND same names.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 1
+} elseif { [get_files -quiet ${design_name}.bd] ne "" } {
+   # USE CASES: 
+   #    6) Current opened design, has components, but diff names, design_name exists in project.
+   #    7) No opened design, design_name exists in project.
+
+   set errMsg "Design <$design_name> already exists in your project, please set the variable <design_name> to another value."
+   set nRet 2
+
+} else {
+   # USE CASES:
+   #    8) No opened design, design_name not in project.
+   #    9) Current opened design, has components, but diff names, design_name not in project.
+
+   common::send_gid_msg -ssname BD::TCL -id 2003 -severity "INFO" "Currently there is no design <$design_name> in project, so creating one..."
+
+   create_bd_design $design_name
+
+   common::send_gid_msg -ssname BD::TCL -id 2004 -severity "INFO" "Making design <$design_name> as current_bd_design."
+   current_bd_design $design_name
+
+}
+
+common::send_gid_msg -ssname BD::TCL -id 2005 -severity "INFO" "Currently the variable <design_name> is equal to \"$design_name\"."
+
+if { $nRet != 0 } {
+   catch {common::send_gid_msg -ssname BD::TCL -id 2006 -severity "ERROR" $errMsg}
+   return $nRet
+}
+
+set bCheckIPsPassed 1
+##################################################################
+# CHECK IPs
+##################################################################
+set bCheckIPs 1
+if { $bCheckIPs == 1 } {
+   set list_check_ips "\ 
+xilinx.com:ip:zynq_ultra_ps_e:3.3\
+"
+
+   set list_ips_missing ""
+   common::send_gid_msg -ssname BD::TCL -id 2011 -severity "INFO" "Checking if the following IPs exist in the project's IP catalog: $list_check_ips ."
+
+   foreach ip_vlnv $list_check_ips {
+      set ip_obj [get_ipdefs -all $ip_vlnv]
+      if { $ip_obj eq "" } {
+         lappend list_ips_missing $ip_vlnv
+      }
+   }
+
+   if { $list_ips_missing ne "" } {
+      catch {common::send_gid_msg -ssname BD::TCL -id 2012 -severity "ERROR" "The following IPs are not found in the IP Catalog:\n  $list_ips_missing\n\nResolution: Please add the repository containing the IP(s) to the project." }
+      set bCheckIPsPassed 0
+   }
+
+}
+
+if { $bCheckIPsPassed != 1 } {
+  common::send_gid_msg -ssname BD::TCL -id 2023 -severity "WARNING" "Will not continue with creation of design due to the error(s) above."
+  return 3
+}
+
+##################################################################
+# DESIGN PROCs
+##################################################################
+
+
+
+# Procedure to create entire design; Provide argument to make
+# procedure reusable. If parentCell is "", will use root.
+proc create_root_design { parentCell } {
+
+  variable script_folder
+  variable design_name
+
+  if { $parentCell eq "" } {
+     set parentCell [get_bd_cells /]
+  }
+
+  # Get object for parentCell
+  set parentObj [get_bd_cells $parentCell]
+  if { $parentObj == "" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2090 -severity "ERROR" "Unable to find parent cell <$parentCell>!"}
+     return
+  }
+
+  # Make sure parentObj is hier blk
+  set parentType [get_property TYPE $parentObj]
+  if { $parentType ne "hier" } {
+     catch {common::send_gid_msg -ssname BD::TCL -id 2091 -severity "ERROR" "Parent <$parentObj> has TYPE = <$parentType>. Expected to be <hier>."}
+     return
+  }
+
+  # Save current instance; Restore later
+  set oldCurInst [current_bd_instance .]
+
+  # Set parent object as current
+  current_bd_instance $parentObj
+
+
+  # Create interface ports
+
+  # Create ports
+  set pl_clk0_0 [ create_bd_port -dir O -type clk pl_clk0_0 ]
+
+  # Create instance: zynq_ultra_ps_e_0, and set properties
+  set zynq_ultra_ps_e_0 [ create_bd_cell -type ip -vlnv xilinx.com:ip:zynq_ultra_ps_e:3.3 zynq_ultra_ps_e_0 ]
+  set_property -dict [ list \
+   CONFIG.PSU_BANK_0_IO_STANDARD {LVCMOS18} \
+   CONFIG.PSU_BANK_1_IO_STANDARD {LVCMOS18} \
+   CONFIG.PSU_BANK_2_IO_STANDARD {LVCMOS18} \
+   CONFIG.PSU_BANK_3_IO_STANDARD {LVCMOS18} \
+   CONFIG.PSU_DDR_RAM_HIGHADDR {0x7FFFFFFF} \
+   CONFIG.PSU_DDR_RAM_HIGHADDR_OFFSET {0x00000002} \
+   CONFIG.PSU_DDR_RAM_LOWADDR_OFFSET {0x80000000} \
+   CONFIG.PSU_DYNAMIC_DDR_CONFIG_EN {0} \
+   CONFIG.PSU_MIO_0_DIRECTION {out} \
+   CONFIG.PSU_MIO_0_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_0_POLARITY {Default} \
+   CONFIG.PSU_MIO_10_DIRECTION {inout} \
+   CONFIG.PSU_MIO_10_POLARITY {Default} \
+   CONFIG.PSU_MIO_11_DIRECTION {inout} \
+   CONFIG.PSU_MIO_11_POLARITY {Default} \
+   CONFIG.PSU_MIO_12_DIRECTION {inout} \
+   CONFIG.PSU_MIO_12_POLARITY {Default} \
+   CONFIG.PSU_MIO_13_DIRECTION {inout} \
+   CONFIG.PSU_MIO_13_DRIVE_STRENGTH {4} \
+   CONFIG.PSU_MIO_13_POLARITY {Default} \
+   CONFIG.PSU_MIO_14_DIRECTION {inout} \
+   CONFIG.PSU_MIO_14_DRIVE_STRENGTH {4} \
+   CONFIG.PSU_MIO_14_POLARITY {Default} \
+   CONFIG.PSU_MIO_15_DIRECTION {inout} \
+   CONFIG.PSU_MIO_15_DRIVE_STRENGTH {4} \
+   CONFIG.PSU_MIO_15_POLARITY {Default} \
+   CONFIG.PSU_MIO_16_DIRECTION {inout} \
+   CONFIG.PSU_MIO_16_DRIVE_STRENGTH {4} \
+   CONFIG.PSU_MIO_16_POLARITY {Default} \
+   CONFIG.PSU_MIO_17_DIRECTION {inout} \
+   CONFIG.PSU_MIO_17_POLARITY {Default} \
+   CONFIG.PSU_MIO_18_DIRECTION {inout} \
+   CONFIG.PSU_MIO_18_POLARITY {Default} \
+   CONFIG.PSU_MIO_19_DIRECTION {inout} \
+   CONFIG.PSU_MIO_19_POLARITY {Default} \
+   CONFIG.PSU_MIO_1_DIRECTION {in} \
+   CONFIG.PSU_MIO_1_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_1_POLARITY {Default} \
+   CONFIG.PSU_MIO_1_SLEW {fast} \
+   CONFIG.PSU_MIO_20_DIRECTION {inout} \
+   CONFIG.PSU_MIO_20_POLARITY {Default} \
+   CONFIG.PSU_MIO_21_DIRECTION {inout} \
+   CONFIG.PSU_MIO_21_DRIVE_STRENGTH {4} \
+   CONFIG.PSU_MIO_21_POLARITY {Default} \
+   CONFIG.PSU_MIO_22_DIRECTION {out} \
+   CONFIG.PSU_MIO_22_DRIVE_STRENGTH {4} \
+   CONFIG.PSU_MIO_22_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_22_POLARITY {Default} \
+   CONFIG.PSU_MIO_23_DIRECTION {inout} \
+   CONFIG.PSU_MIO_23_POLARITY {Default} \
+   CONFIG.PSU_MIO_24_DIRECTION {in} \
+   CONFIG.PSU_MIO_24_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_24_POLARITY {Default} \
+   CONFIG.PSU_MIO_24_SLEW {fast} \
+   CONFIG.PSU_MIO_25_DIRECTION {inout} \
+   CONFIG.PSU_MIO_25_POLARITY {Default} \
+   CONFIG.PSU_MIO_26_DIRECTION {in} \
+   CONFIG.PSU_MIO_26_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_26_POLARITY {Default} \
+   CONFIG.PSU_MIO_26_SLEW {fast} \
+   CONFIG.PSU_MIO_27_DIRECTION {out} \
+   CONFIG.PSU_MIO_27_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_27_POLARITY {Default} \
+   CONFIG.PSU_MIO_28_DIRECTION {in} \
+   CONFIG.PSU_MIO_28_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_28_POLARITY {Default} \
+   CONFIG.PSU_MIO_28_SLEW {fast} \
+   CONFIG.PSU_MIO_29_DIRECTION {out} \
+   CONFIG.PSU_MIO_29_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_29_POLARITY {Default} \
+   CONFIG.PSU_MIO_2_DIRECTION {in} \
+   CONFIG.PSU_MIO_2_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_2_POLARITY {Default} \
+   CONFIG.PSU_MIO_2_SLEW {fast} \
+   CONFIG.PSU_MIO_30_DIRECTION {in} \
+   CONFIG.PSU_MIO_30_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_30_POLARITY {Default} \
+   CONFIG.PSU_MIO_30_SLEW {fast} \
+   CONFIG.PSU_MIO_31_DIRECTION {inout} \
+   CONFIG.PSU_MIO_31_POLARITY {Default} \
+   CONFIG.PSU_MIO_32_DIRECTION {out} \
+   CONFIG.PSU_MIO_32_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_32_POLARITY {Default} \
+   CONFIG.PSU_MIO_33_DIRECTION {out} \
+   CONFIG.PSU_MIO_33_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_33_POLARITY {Default} \
+   CONFIG.PSU_MIO_34_DIRECTION {out} \
+   CONFIG.PSU_MIO_34_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_34_POLARITY {Default} \
+   CONFIG.PSU_MIO_35_DIRECTION {inout} \
+   CONFIG.PSU_MIO_35_POLARITY {Default} \
+   CONFIG.PSU_MIO_36_DIRECTION {inout} \
+   CONFIG.PSU_MIO_36_POLARITY {Default} \
+   CONFIG.PSU_MIO_37_DIRECTION {inout} \
+   CONFIG.PSU_MIO_37_POLARITY {Default} \
+   CONFIG.PSU_MIO_38_DIRECTION {inout} \
+   CONFIG.PSU_MIO_38_POLARITY {Default} \
+   CONFIG.PSU_MIO_39_DIRECTION {inout} \
+   CONFIG.PSU_MIO_39_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_39_POLARITY {Default} \
+   CONFIG.PSU_MIO_39_SLEW {fast} \
+   CONFIG.PSU_MIO_3_DIRECTION {out} \
+   CONFIG.PSU_MIO_3_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_3_POLARITY {Default} \
+   CONFIG.PSU_MIO_40_DIRECTION {inout} \
+   CONFIG.PSU_MIO_40_POLARITY {Default} \
+   CONFIG.PSU_MIO_41_DIRECTION {inout} \
+   CONFIG.PSU_MIO_41_POLARITY {Default} \
+   CONFIG.PSU_MIO_42_DIRECTION {inout} \
+   CONFIG.PSU_MIO_42_POLARITY {Default} \
+   CONFIG.PSU_MIO_43_DIRECTION {inout} \
+   CONFIG.PSU_MIO_43_POLARITY {Default} \
+   CONFIG.PSU_MIO_44_DIRECTION {inout} \
+   CONFIG.PSU_MIO_44_POLARITY {Default} \
+   CONFIG.PSU_MIO_45_DIRECTION {inout} \
+   CONFIG.PSU_MIO_45_POLARITY {Default} \
+   CONFIG.PSU_MIO_46_DIRECTION {inout} \
+   CONFIG.PSU_MIO_46_POLARITY {Default} \
+   CONFIG.PSU_MIO_47_DIRECTION {inout} \
+   CONFIG.PSU_MIO_47_POLARITY {Default} \
+   CONFIG.PSU_MIO_48_DIRECTION {inout} \
+   CONFIG.PSU_MIO_48_POLARITY {Default} \
+   CONFIG.PSU_MIO_49_DIRECTION {inout} \
+   CONFIG.PSU_MIO_49_POLARITY {Default} \
+   CONFIG.PSU_MIO_4_DIRECTION {inout} \
+   CONFIG.PSU_MIO_4_POLARITY {Default} \
+   CONFIG.PSU_MIO_50_DIRECTION {inout} \
+   CONFIG.PSU_MIO_50_POLARITY {Default} \
+   CONFIG.PSU_MIO_51_DIRECTION {out} \
+   CONFIG.PSU_MIO_51_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_51_POLARITY {Default} \
+   CONFIG.PSU_MIO_52_DIRECTION {in} \
+   CONFIG.PSU_MIO_52_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_52_POLARITY {Default} \
+   CONFIG.PSU_MIO_52_SLEW {fast} \
+   CONFIG.PSU_MIO_53_DIRECTION {in} \
+   CONFIG.PSU_MIO_53_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_53_POLARITY {Default} \
+   CONFIG.PSU_MIO_53_SLEW {fast} \
+   CONFIG.PSU_MIO_54_DIRECTION {inout} \
+   CONFIG.PSU_MIO_54_POLARITY {Default} \
+   CONFIG.PSU_MIO_55_DIRECTION {in} \
+   CONFIG.PSU_MIO_55_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_55_POLARITY {Default} \
+   CONFIG.PSU_MIO_55_SLEW {fast} \
+   CONFIG.PSU_MIO_56_DIRECTION {inout} \
+   CONFIG.PSU_MIO_56_POLARITY {Default} \
+   CONFIG.PSU_MIO_57_DIRECTION {inout} \
+   CONFIG.PSU_MIO_57_POLARITY {Default} \
+   CONFIG.PSU_MIO_58_DIRECTION {out} \
+   CONFIG.PSU_MIO_58_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_58_POLARITY {Default} \
+   CONFIG.PSU_MIO_59_DIRECTION {inout} \
+   CONFIG.PSU_MIO_59_POLARITY {Default} \
+   CONFIG.PSU_MIO_5_DIRECTION {inout} \
+   CONFIG.PSU_MIO_5_POLARITY {Default} \
+   CONFIG.PSU_MIO_60_DIRECTION {inout} \
+   CONFIG.PSU_MIO_60_POLARITY {Default} \
+   CONFIG.PSU_MIO_61_DIRECTION {inout} \
+   CONFIG.PSU_MIO_61_POLARITY {Default} \
+   CONFIG.PSU_MIO_62_DIRECTION {inout} \
+   CONFIG.PSU_MIO_62_POLARITY {Default} \
+   CONFIG.PSU_MIO_63_DIRECTION {inout} \
+   CONFIG.PSU_MIO_63_POLARITY {Default} \
+   CONFIG.PSU_MIO_64_DIRECTION {in} \
+   CONFIG.PSU_MIO_64_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_64_POLARITY {Default} \
+   CONFIG.PSU_MIO_64_SLEW {fast} \
+   CONFIG.PSU_MIO_65_DIRECTION {in} \
+   CONFIG.PSU_MIO_65_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_65_POLARITY {Default} \
+   CONFIG.PSU_MIO_65_SLEW {fast} \
+   CONFIG.PSU_MIO_66_DIRECTION {inout} \
+   CONFIG.PSU_MIO_66_POLARITY {Default} \
+   CONFIG.PSU_MIO_67_DIRECTION {in} \
+   CONFIG.PSU_MIO_67_DRIVE_STRENGTH {12} \
+   CONFIG.PSU_MIO_67_POLARITY {Default} \
+   CONFIG.PSU_MIO_67_SLEW {fast} \
+   CONFIG.PSU_MIO_68_DIRECTION {inout} \
+   CONFIG.PSU_MIO_68_POLARITY {Default} \
+   CONFIG.PSU_MIO_69_DIRECTION {inout} \
+   CONFIG.PSU_MIO_69_POLARITY {Default} \
+   CONFIG.PSU_MIO_6_DIRECTION {inout} \
+   CONFIG.PSU_MIO_6_POLARITY {Default} \
+   CONFIG.PSU_MIO_70_DIRECTION {out} \
+   CONFIG.PSU_MIO_70_INPUT_TYPE {cmos} \
+   CONFIG.PSU_MIO_70_POLARITY {Default} \
+   CONFIG.PSU_MIO_71_DIRECTION {inout} \
+   CONFIG.PSU_MIO_71_POLARITY {Default} \
+   CONFIG.PSU_MIO_72_DIRECTION {inout} \
+   CONFIG.PSU_MIO_72_POLARITY {Default} \
+   CONFIG.PSU_MIO_73_DIRECTION {inout} \
+   CONFIG.PSU_MIO_73_POLARITY {Default} \
+   CONFIG.PSU_MIO_74_DIRECTION {inout} \
+   CONFIG.PSU_MIO_74_POLARITY {Default} \
+   CONFIG.PSU_MIO_75_DIRECTION {inout} \
+   CONFIG.PSU_MIO_75_POLARITY {Default} \
+   CONFIG.PSU_MIO_76_DIRECTION {inout} \
+   CONFIG.PSU_MIO_76_POLARITY {Default} \
+   CONFIG.PSU_MIO_77_DIRECTION {inout} \
+   CONFIG.PSU_MIO_77_POLARITY {Default} \
+   CONFIG.PSU_MIO_7_DIRECTION {inout} \
+   CONFIG.PSU_MIO_7_POLARITY {Default} \
+   CONFIG.PSU_MIO_8_DIRECTION {inout} \
+   CONFIG.PSU_MIO_8_POLARITY {Default} \
+   CONFIG.PSU_MIO_9_DIRECTION {inout} \
+   CONFIG.PSU_MIO_9_POLARITY {Default} \
+   CONFIG.PSU_MIO_TREE_PERIPHERALS {UART 1#UART 1#UART 0#UART 0#I2C 1#I2C 1#SPI 1#GPIO0 MIO#GPIO0 MIO#SPI 1#SPI 1#SPI 1#GPIO0 MIO#SD 0#SD 0#SD 0#SD 0#GPIO0 MIO#GPIO0 MIO#GPIO0 MIO#GPIO0 MIO#SD 0#SD 0#GPIO0 MIO#SD 0#GPIO0 MIO#PMU GPI 0#DPAUX#DPAUX#DPAUX#DPAUX#GPIO1 MIO#PMU GPO 0#PMU GPO 1#PMU GPO 2#GPIO1 MIO#GPIO1 MIO#GPIO1 MIO#SPI 0#GPIO1 MIO#GPIO1 MIO#SPI 0#SPI 0#SPI 0#GPIO1 MIO#GPIO1 MIO#SD 1#SD 1#SD 1#SD 1#SD 1#SD 1#USB 0#USB 0#USB 0#USB 0#USB 0#USB 0#USB 0#USB 0#USB 0#USB 0#USB 0#USB 0#USB 1#USB 1#USB 1#USB 1#USB 1#USB 1#USB 1#USB 1#USB 1#USB 1#USB 1#USB 1#GPIO2 MIO#GPIO2 MIO} \
+   CONFIG.PSU_MIO_TREE_SIGNALS {txd#rxd#rxd#txd#scl_out#sda_out#sclk_out#gpio0[7]#gpio0[8]#n_ss_out[0]#miso#mosi#gpio0[12]#sdio0_data_out[0]#sdio0_data_out[1]#sdio0_data_out[2]#sdio0_data_out[3]#gpio0[17]#gpio0[18]#gpio0[19]#gpio0[20]#sdio0_cmd_out#sdio0_clk_out#gpio0[23]#sdio0_cd_n#gpio0[25]#gpi[0]#dp_aux_data_out#dp_hot_plug_detect#dp_aux_data_oe#dp_aux_data_in#gpio1[31]#gpo[0]#gpo[1]#gpo[2]#gpio1[35]#gpio1[36]#gpio1[37]#sclk_out#gpio1[39]#gpio1[40]#n_ss_out[0]#miso#mosi#gpio1[44]#gpio1[45]#sdio1_data_out[0]#sdio1_data_out[1]#sdio1_data_out[2]#sdio1_data_out[3]#sdio1_cmd_out#sdio1_clk_out#ulpi_clk_in#ulpi_dir#ulpi_tx_data[2]#ulpi_nxt#ulpi_tx_data[0]#ulpi_tx_data[1]#ulpi_stp#ulpi_tx_data[3]#ulpi_tx_data[4]#ulpi_tx_data[5]#ulpi_tx_data[6]#ulpi_tx_data[7]#ulpi_clk_in#ulpi_dir#ulpi_tx_data[2]#ulpi_nxt#ulpi_tx_data[0]#ulpi_tx_data[1]#ulpi_stp#ulpi_tx_data[3]#ulpi_tx_data[4]#ulpi_tx_data[5]#ulpi_tx_data[6]#ulpi_tx_data[7]#gpio2[76]#gpio2[77]} \
+   CONFIG.PSU_SD0_INTERNAL_BUS_WIDTH {4} \
+   CONFIG.PSU_SD1_INTERNAL_BUS_WIDTH {4} \
+   CONFIG.PSU_USB3__DUAL_CLOCK_ENABLE {1} \
+   CONFIG.PSU__ACT_DDR_FREQ_MHZ {533.333313} \
+   CONFIG.PSU__CAN1__GRP_CLK__ENABLE {0} \
+   CONFIG.PSU__CAN1__PERIPHERAL__ENABLE {0} \
+   CONFIG.PSU__CRF_APB__ACPU_CTRL__ACT_FREQMHZ {1200.000000} \
+   CONFIG.PSU__CRF_APB__ACPU_CTRL__DIVISOR0 {1} \
+   CONFIG.PSU__CRF_APB__ACPU_CTRL__SRCSEL {APLL} \
+   CONFIG.PSU__CRF_APB__APLL_CTRL__DIV2 {1} \
+   CONFIG.PSU__CRF_APB__APLL_CTRL__FBDIV {72} \
+   CONFIG.PSU__CRF_APB__APLL_CTRL__FRACDATA {0} \
+   CONFIG.PSU__CRF_APB__APLL_CTRL__SRCSEL {PSS_REF_CLK} \
+   CONFIG.PSU__CRF_APB__APLL_FRAC_CFG__ENABLED {0} \
+   CONFIG.PSU__CRF_APB__APLL_TO_LPD_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRF_APB__DBG_FPD_CTRL__ACT_FREQMHZ {250.000000} \
+   CONFIG.PSU__CRF_APB__DBG_FPD_CTRL__DIVISOR0 {2} \
+   CONFIG.PSU__CRF_APB__DBG_FPD_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRF_APB__DBG_TRACE_CTRL__DIVISOR0 {2} \
+   CONFIG.PSU__CRF_APB__DBG_TRACE_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRF_APB__DBG_TSTMP_CTRL__ACT_FREQMHZ {250.000000} \
+   CONFIG.PSU__CRF_APB__DBG_TSTMP_CTRL__DIVISOR0 {2} \
+   CONFIG.PSU__CRF_APB__DBG_TSTMP_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRF_APB__DDR_CTRL__ACT_FREQMHZ {266.666656} \
+   CONFIG.PSU__CRF_APB__DDR_CTRL__DIVISOR0 {4} \
+   CONFIG.PSU__CRF_APB__DDR_CTRL__FREQMHZ {533} \
+   CONFIG.PSU__CRF_APB__DDR_CTRL__SRCSEL {DPLL} \
+   CONFIG.PSU__CRF_APB__DPDMA_REF_CTRL__ACT_FREQMHZ {600.000000} \
+   CONFIG.PSU__CRF_APB__DPDMA_REF_CTRL__DIVISOR0 {2} \
+   CONFIG.PSU__CRF_APB__DPDMA_REF_CTRL__SRCSEL {APLL} \
+   CONFIG.PSU__CRF_APB__DPLL_CTRL__DIV2 {1} \
+   CONFIG.PSU__CRF_APB__DPLL_CTRL__FBDIV {64} \
+   CONFIG.PSU__CRF_APB__DPLL_CTRL__FRACDATA {0} \
+   CONFIG.PSU__CRF_APB__DPLL_CTRL__SRCSEL {PSS_REF_CLK} \
+   CONFIG.PSU__CRF_APB__DPLL_FRAC_CFG__ENABLED {0} \
+   CONFIG.PSU__CRF_APB__DPLL_TO_LPD_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRF_APB__DP_AUDIO_REF_CTRL__ACT_FREQMHZ {24.576040} \
+   CONFIG.PSU__CRF_APB__DP_AUDIO_REF_CTRL__DIVISOR0 {16} \
+   CONFIG.PSU__CRF_APB__DP_AUDIO_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRF_APB__DP_AUDIO_REF_CTRL__SRCSEL {RPLL} \
+   CONFIG.PSU__CRF_APB__DP_AUDIO__FRAC_ENABLED {1} \
+   CONFIG.PSU__CRF_APB__DP_STC_REF_CTRL__ACT_FREQMHZ {26.214443} \
+   CONFIG.PSU__CRF_APB__DP_STC_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRF_APB__DP_STC_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRF_APB__DP_STC_REF_CTRL__SRCSEL {RPLL} \
+   CONFIG.PSU__CRF_APB__DP_VIDEO_REF_CTRL__ACT_FREQMHZ {297.029572} \
+   CONFIG.PSU__CRF_APB__DP_VIDEO_REF_CTRL__DIVISOR0 {4} \
+   CONFIG.PSU__CRF_APB__DP_VIDEO_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRF_APB__DP_VIDEO_REF_CTRL__SRCSEL {VPLL} \
+   CONFIG.PSU__CRF_APB__DP_VIDEO__FRAC_ENABLED {1} \
+   CONFIG.PSU__CRF_APB__GDMA_REF_CTRL__ACT_FREQMHZ {600.000000} \
+   CONFIG.PSU__CRF_APB__GDMA_REF_CTRL__DIVISOR0 {2} \
+   CONFIG.PSU__CRF_APB__GDMA_REF_CTRL__SRCSEL {APLL} \
+   CONFIG.PSU__CRF_APB__GPU_REF_CTRL__ACT_FREQMHZ {500.000000} \
+   CONFIG.PSU__CRF_APB__GPU_REF_CTRL__DIVISOR0 {1} \
+   CONFIG.PSU__CRF_APB__GPU_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRF_APB__PCIE_REF_CTRL__DIVISOR0 {2} \
+   CONFIG.PSU__CRF_APB__PCIE_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRF_APB__SATA_REF_CTRL__DIVISOR0 {2} \
+   CONFIG.PSU__CRF_APB__SATA_REF_CTRL__FREQMHZ {250} \
+   CONFIG.PSU__CRF_APB__SATA_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRF_APB__TOPSW_LSBUS_CTRL__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__CRF_APB__TOPSW_LSBUS_CTRL__DIVISOR0 {5} \
+   CONFIG.PSU__CRF_APB__TOPSW_LSBUS_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRF_APB__TOPSW_MAIN_CTRL__ACT_FREQMHZ {533.333313} \
+   CONFIG.PSU__CRF_APB__TOPSW_MAIN_CTRL__DIVISOR0 {2} \
+   CONFIG.PSU__CRF_APB__TOPSW_MAIN_CTRL__SRCSEL {DPLL} \
+   CONFIG.PSU__CRF_APB__VPLL_CTRL__DIV2 {1} \
+   CONFIG.PSU__CRF_APB__VPLL_CTRL__FBDIV {71} \
+   CONFIG.PSU__CRF_APB__VPLL_CTRL__FRACDATA {0.2871} \
+   CONFIG.PSU__CRF_APB__VPLL_CTRL__FRACFREQ {300} \
+   CONFIG.PSU__CRF_APB__VPLL_CTRL__SRCSEL {PSS_REF_CLK} \
+   CONFIG.PSU__CRF_APB__VPLL_FRAC_CFG__ENABLED {1} \
+   CONFIG.PSU__CRF_APB__VPLL_TO_LPD_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRL_APB__ADMA_REF_CTRL__ACT_FREQMHZ {500.000000} \
+   CONFIG.PSU__CRL_APB__ADMA_REF_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRL_APB__ADMA_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__AFI6_REF_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRL_APB__AMS_REF_CTRL__ACT_FREQMHZ {51.724136} \
+   CONFIG.PSU__CRL_APB__AMS_REF_CTRL__DIVISOR0 {29} \
+   CONFIG.PSU__CRL_APB__AMS_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__AMS_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__CAN0_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__CAN0_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__CAN0_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__CAN1_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__CAN1_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__CAN1_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__CPU_R5_CTRL__ACT_FREQMHZ {500.000000} \
+   CONFIG.PSU__CRL_APB__CPU_R5_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRL_APB__CPU_R5_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__CSU_PLL_CTRL__ACT_FREQMHZ {500} \
+   CONFIG.PSU__CRL_APB__CSU_PLL_CTRL__DIVISOR0 {4} \
+   CONFIG.PSU__CRL_APB__CSU_PLL_CTRL__FREQMHZ {400} \
+   CONFIG.PSU__CRL_APB__CSU_PLL_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__DBG_LPD_CTRL__ACT_FREQMHZ {250.000000} \
+   CONFIG.PSU__CRL_APB__DBG_LPD_CTRL__DIVISOR0 {6} \
+   CONFIG.PSU__CRL_APB__DBG_LPD_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__DLL_REF_CTRL__ACT_FREQMHZ {1500.000000} \
+   CONFIG.PSU__CRL_APB__GEM0_REF_CTRL__DIVISOR0 {12} \
+   CONFIG.PSU__CRL_APB__GEM0_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__GEM0_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__GEM1_REF_CTRL__DIVISOR0 {12} \
+   CONFIG.PSU__CRL_APB__GEM1_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__GEM1_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__GEM2_REF_CTRL__DIVISOR0 {12} \
+   CONFIG.PSU__CRL_APB__GEM2_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__GEM2_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__GEM3_REF_CTRL__DIVISOR0 {12} \
+   CONFIG.PSU__CRL_APB__GEM3_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__GEM3_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__GEM_TSU_REF_CTRL__DIVISOR0 {6} \
+   CONFIG.PSU__CRL_APB__GEM_TSU_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__GEM_TSU_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__I2C0_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__I2C0_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__I2C0_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__I2C1_REF_CTRL__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__CRL_APB__I2C1_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__I2C1_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__I2C1_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__IOPLL_CTRL__DIV2 {0} \
+   CONFIG.PSU__CRL_APB__IOPLL_CTRL__FBDIV {45} \
+   CONFIG.PSU__CRL_APB__IOPLL_CTRL__FRACDATA {0} \
+   CONFIG.PSU__CRL_APB__IOPLL_CTRL__SRCSEL {PSS_REF_CLK} \
+   CONFIG.PSU__CRL_APB__IOPLL_FRAC_CFG__ENABLED {0} \
+   CONFIG.PSU__CRL_APB__IOPLL_TO_FPD_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRL_APB__IOU_SWITCH_CTRL__ACT_FREQMHZ {250.000000} \
+   CONFIG.PSU__CRL_APB__IOU_SWITCH_CTRL__DIVISOR0 {6} \
+   CONFIG.PSU__CRL_APB__IOU_SWITCH_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__LPD_LSBUS_CTRL__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__CRL_APB__LPD_LSBUS_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__LPD_LSBUS_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__LPD_SWITCH_CTRL__ACT_FREQMHZ {500.000000} \
+   CONFIG.PSU__CRL_APB__LPD_SWITCH_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRL_APB__LPD_SWITCH_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__NAND_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__NAND_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__NAND_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__PCAP_CTRL__ACT_FREQMHZ {187.500000} \
+   CONFIG.PSU__CRL_APB__PCAP_CTRL__DIVISOR0 {8} \
+   CONFIG.PSU__CRL_APB__PCAP_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__PL0_REF_CTRL__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__CRL_APB__PL0_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__PL0_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__PL0_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__PL1_REF_CTRL__ACT_FREQMHZ {25.000000} \
+   CONFIG.PSU__CRL_APB__PL1_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__PL1_REF_CTRL__DIVISOR1 {4} \
+   CONFIG.PSU__CRL_APB__PL1_REF_CTRL__FREQMHZ {100} \
+   CONFIG.PSU__CRL_APB__PL1_REF_CTRL__SRCSEL {RPLL} \
+   CONFIG.PSU__CRL_APB__PL2_REF_CTRL__ACT_FREQMHZ {299.999700} \
+   CONFIG.PSU__CRL_APB__PL2_REF_CTRL__DIVISOR0 {5} \
+   CONFIG.PSU__CRL_APB__PL2_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__PL2_REF_CTRL__FREQMHZ {100} \
+   CONFIG.PSU__CRL_APB__PL2_REF_CTRL__SRCSEL {RPLL} \
+   CONFIG.PSU__CRL_APB__PL3_REF_CTRL__ACT_FREQMHZ {374.999625} \
+   CONFIG.PSU__CRL_APB__PL3_REF_CTRL__DIVISOR0 {4} \
+   CONFIG.PSU__CRL_APB__PL3_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__PL3_REF_CTRL__FREQMHZ {100} \
+   CONFIG.PSU__CRL_APB__PL3_REF_CTRL__SRCSEL {RPLL} \
+   CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__DIVISOR0 {12} \
+   CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__QSPI_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__RPLL_CTRL__DIV2 {1} \
+   CONFIG.PSU__CRL_APB__RPLL_CTRL__FBDIV {70} \
+   CONFIG.PSU__CRL_APB__RPLL_CTRL__FRACDATA {0.779} \
+   CONFIG.PSU__CRL_APB__RPLL_CTRL__FRACFREQ {25} \
+   CONFIG.PSU__CRL_APB__RPLL_CTRL__SRCSEL {PSS_REF_CLK} \
+   CONFIG.PSU__CRL_APB__RPLL_FRAC_CFG__ENABLED {1} \
+   CONFIG.PSU__CRL_APB__RPLL_TO_FPD_CTRL__DIVISOR0 {3} \
+   CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__ACT_FREQMHZ {187.500000} \
+   CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__DIVISOR0 {8} \
+   CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__SDIO0_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__ACT_FREQMHZ {187.500000} \
+   CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__DIVISOR0 {8} \
+   CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__SDIO1_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__SPI0_REF_CTRL__ACT_FREQMHZ {187.500000} \
+   CONFIG.PSU__CRL_APB__SPI0_REF_CTRL__DIVISOR0 {8} \
+   CONFIG.PSU__CRL_APB__SPI0_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__SPI0_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__SPI1_REF_CTRL__ACT_FREQMHZ {187.500000} \
+   CONFIG.PSU__CRL_APB__SPI1_REF_CTRL__DIVISOR0 {8} \
+   CONFIG.PSU__CRL_APB__SPI1_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__SPI1_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__TIMESTAMP_REF_CTRL__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__CRL_APB__TIMESTAMP_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__TIMESTAMP_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__UART0_REF_CTRL__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__CRL_APB__UART0_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__UART0_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__UART0_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__UART1_REF_CTRL__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__CRL_APB__UART1_REF_CTRL__DIVISOR0 {15} \
+   CONFIG.PSU__CRL_APB__UART1_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__UART1_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__USB0_BUS_REF_CTRL__ACT_FREQMHZ {250.000000} \
+   CONFIG.PSU__CRL_APB__USB0_BUS_REF_CTRL__DIVISOR0 {6} \
+   CONFIG.PSU__CRL_APB__USB0_BUS_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__USB0_BUS_REF_CTRL__FREQMHZ {250} \
+   CONFIG.PSU__CRL_APB__USB0_BUS_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__USB1_BUS_REF_CTRL__ACT_FREQMHZ {250.000000} \
+   CONFIG.PSU__CRL_APB__USB1_BUS_REF_CTRL__DIVISOR0 {6} \
+   CONFIG.PSU__CRL_APB__USB1_BUS_REF_CTRL__DIVISOR1 {1} \
+   CONFIG.PSU__CRL_APB__USB1_BUS_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__USB3_DUAL_REF_CTRL__ACT_FREQMHZ {20.000000} \
+   CONFIG.PSU__CRL_APB__USB3_DUAL_REF_CTRL__DIVISOR0 {5} \
+   CONFIG.PSU__CRL_APB__USB3_DUAL_REF_CTRL__DIVISOR1 {15} \
+   CONFIG.PSU__CRL_APB__USB3_DUAL_REF_CTRL__FREQMHZ {20} \
+   CONFIG.PSU__CRL_APB__USB3_DUAL_REF_CTRL__SRCSEL {IOPLL} \
+   CONFIG.PSU__CRL_APB__USB3__ENABLE {1} \
+   CONFIG.PSU__CSUPMU__PERIPHERAL__VALID {1} \
+   CONFIG.PSU__DDRC__ADDR_MIRROR {1} \
+   CONFIG.PSU__DDRC__AL {0} \
+   CONFIG.PSU__DDRC__BANK_ADDR_COUNT {3} \
+   CONFIG.PSU__DDRC__BG_ADDR_COUNT {NA} \
+   CONFIG.PSU__DDRC__BRC_MAPPING {ROW_BANK_COL} \
+   CONFIG.PSU__DDRC__BUS_WIDTH {32 Bit} \
+   CONFIG.PSU__DDRC__CL {NA} \
+   CONFIG.PSU__DDRC__CLOCK_STOP_EN {0} \
+   CONFIG.PSU__DDRC__COL_ADDR_COUNT {10} \
+   CONFIG.PSU__DDRC__COMPONENTS {Components} \
+   CONFIG.PSU__DDRC__CWL {NA} \
+   CONFIG.PSU__DDRC__DDR3L_T_REF_RANGE {NA} \
+   CONFIG.PSU__DDRC__DDR3_T_REF_RANGE {NA} \
+   CONFIG.PSU__DDRC__DDR4_ADDR_MAPPING {NA} \
+   CONFIG.PSU__DDRC__DDR4_CAL_MODE_ENABLE {NA} \
+   CONFIG.PSU__DDRC__DDR4_CRC_CONTROL {NA} \
+   CONFIG.PSU__DDRC__DDR4_MAXPWR_SAVING_EN {NA} \
+   CONFIG.PSU__DDRC__DDR4_T_REF_MODE {NA} \
+   CONFIG.PSU__DDRC__DDR4_T_REF_RANGE {NA} \
+   CONFIG.PSU__DDRC__DEEP_PWR_DOWN_EN {0} \
+   CONFIG.PSU__DDRC__DEVICE_CAPACITY {16384 MBits} \
+   CONFIG.PSU__DDRC__DIMM_ADDR_MIRROR {0} \
+   CONFIG.PSU__DDRC__DM_DBI {DM_NO_DBI} \
+   CONFIG.PSU__DDRC__DQMAP_0_3 {0} \
+   CONFIG.PSU__DDRC__DQMAP_12_15 {0} \
+   CONFIG.PSU__DDRC__DQMAP_16_19 {0} \
+   CONFIG.PSU__DDRC__DQMAP_20_23 {0} \
+   CONFIG.PSU__DDRC__DQMAP_24_27 {0} \
+   CONFIG.PSU__DDRC__DQMAP_28_31 {0} \
+   CONFIG.PSU__DDRC__DQMAP_32_35 {0} \
+   CONFIG.PSU__DDRC__DQMAP_36_39 {0} \
+   CONFIG.PSU__DDRC__DQMAP_40_43 {0} \
+   CONFIG.PSU__DDRC__DQMAP_44_47 {0} \
+   CONFIG.PSU__DDRC__DQMAP_48_51 {0} \
+   CONFIG.PSU__DDRC__DQMAP_4_7 {0} \
+   CONFIG.PSU__DDRC__DQMAP_52_55 {0} \
+   CONFIG.PSU__DDRC__DQMAP_56_59 {0} \
+   CONFIG.PSU__DDRC__DQMAP_60_63 {0} \
+   CONFIG.PSU__DDRC__DQMAP_64_67 {0} \
+   CONFIG.PSU__DDRC__DQMAP_68_71 {0} \
+   CONFIG.PSU__DDRC__DQMAP_8_11 {0} \
+   CONFIG.PSU__DDRC__DRAM_WIDTH {32 Bits} \
+   CONFIG.PSU__DDRC__ECC {Disabled} \
+   CONFIG.PSU__DDRC__ENABLE_2T_TIMING {0} \
+   CONFIG.PSU__DDRC__ENABLE_DP_SWITCH {1} \
+   CONFIG.PSU__DDRC__ENABLE_LP4_HAS_ECC_COMP {0} \
+   CONFIG.PSU__DDRC__ENABLE_LP4_SLOWBOOT {0} \
+   CONFIG.PSU__DDRC__FGRM {NA} \
+   CONFIG.PSU__DDRC__LPDDR3_T_REF_RANGE {NA} \
+   CONFIG.PSU__DDRC__LPDDR4_T_REF_RANGE {High (95 Max)} \
+   CONFIG.PSU__DDRC__LP_ASR {NA} \
+   CONFIG.PSU__DDRC__MEMORY_TYPE {LPDDR 4} \
+   CONFIG.PSU__DDRC__PARITY_ENABLE {NA} \
+   CONFIG.PSU__DDRC__PER_BANK_REFRESH {0} \
+   CONFIG.PSU__DDRC__PHY_DBI_MODE {0} \
+   CONFIG.PSU__DDRC__RANK_ADDR_COUNT {0} \
+   CONFIG.PSU__DDRC__ROW_ADDR_COUNT {16} \
+   CONFIG.PSU__DDRC__SB_TARGET {NA} \
+   CONFIG.PSU__DDRC__SELF_REF_ABORT {NA} \
+   CONFIG.PSU__DDRC__SPEED_BIN {LPDDR4_1066} \
+   CONFIG.PSU__DDRC__STATIC_RD_MODE {0} \
+   CONFIG.PSU__DDRC__TRAIN_DATA_EYE {1} \
+   CONFIG.PSU__DDRC__TRAIN_READ_GATE {1} \
+   CONFIG.PSU__DDRC__TRAIN_WRITE_LEVEL {1} \
+   CONFIG.PSU__DDRC__T_FAW {40.0} \
+   CONFIG.PSU__DDRC__T_RAS_MIN {42} \
+   CONFIG.PSU__DDRC__T_RC {63} \
+   CONFIG.PSU__DDRC__T_RCD {10} \
+   CONFIG.PSU__DDRC__T_RP {12} \
+   CONFIG.PSU__DDRC__VENDOR_PART {OTHERS} \
+   CONFIG.PSU__DDRC__VREF {0} \
+   CONFIG.PSU__DDR_HIGH_ADDRESS_GUI_ENABLE {0} \
+   CONFIG.PSU__DDR_QOS_ENABLE {1} \
+   CONFIG.PSU__DDR_QOS_FIX_HP0_RDQOS {7} \
+   CONFIG.PSU__DDR_QOS_FIX_HP0_WRQOS {15} \
+   CONFIG.PSU__DDR_QOS_FIX_HP1_RDQOS {3} \
+   CONFIG.PSU__DDR_QOS_FIX_HP1_WRQOS {3} \
+   CONFIG.PSU__DDR_QOS_FIX_HP2_RDQOS {3} \
+   CONFIG.PSU__DDR_QOS_FIX_HP2_WRQOS {3} \
+   CONFIG.PSU__DDR_QOS_FIX_HP3_RDQOS {3} \
+   CONFIG.PSU__DDR_QOS_FIX_HP3_WRQOS {3} \
+   CONFIG.PSU__DDR_QOS_HP0_RDQOS {7} \
+   CONFIG.PSU__DDR_QOS_HP0_WRQOS {15} \
+   CONFIG.PSU__DDR_QOS_HP1_RDQOS {3} \
+   CONFIG.PSU__DDR_QOS_HP1_WRQOS {3} \
+   CONFIG.PSU__DDR_QOS_HP2_RDQOS {3} \
+   CONFIG.PSU__DDR_QOS_HP2_WRQOS {3} \
+   CONFIG.PSU__DDR_QOS_HP3_RDQOS {3} \
+   CONFIG.PSU__DDR_QOS_HP3_WRQOS {3} \
+   CONFIG.PSU__DDR_QOS_PORT0_TYPE {Low Latency} \
+   CONFIG.PSU__DDR_QOS_PORT1_VN1_TYPE {Low Latency} \
+   CONFIG.PSU__DDR_QOS_PORT1_VN2_TYPE {Best Effort} \
+   CONFIG.PSU__DDR_QOS_PORT2_VN1_TYPE {Low Latency} \
+   CONFIG.PSU__DDR_QOS_PORT2_VN2_TYPE {Best Effort} \
+   CONFIG.PSU__DDR_QOS_PORT3_TYPE {Video Traffic} \
+   CONFIG.PSU__DDR_QOS_PORT4_TYPE {Best Effort} \
+   CONFIG.PSU__DDR_QOS_PORT5_TYPE {Best Effort} \
+   CONFIG.PSU__DDR_QOS_RD_HPR_THRSHLD {0} \
+   CONFIG.PSU__DDR_QOS_RD_LPR_THRSHLD {16} \
+   CONFIG.PSU__DDR_QOS_WR_THRSHLD {16} \
+   CONFIG.PSU__DDR__INTERFACE__FREQMHZ {266.500} \
+   CONFIG.PSU__DISPLAYPORT__LANE0__ENABLE {1} \
+   CONFIG.PSU__DISPLAYPORT__LANE0__IO {GT Lane1} \
+   CONFIG.PSU__DISPLAYPORT__LANE1__ENABLE {1} \
+   CONFIG.PSU__DISPLAYPORT__LANE1__IO {GT Lane0} \
+   CONFIG.PSU__DISPLAYPORT__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__DLL__ISUSED {1} \
+   CONFIG.PSU__DPAUX__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__DPAUX__PERIPHERAL__IO {MIO 27 .. 30} \
+   CONFIG.PSU__DP__LANE_SEL {Dual Lower} \
+   CONFIG.PSU__DP__REF_CLK_FREQ {27} \
+   CONFIG.PSU__DP__REF_CLK_SEL {Ref Clk1} \
+   CONFIG.PSU__ENET3__FIFO__ENABLE {0} \
+   CONFIG.PSU__ENET3__GRP_MDIO__ENABLE {0} \
+   CONFIG.PSU__ENET3__PERIPHERAL__ENABLE {0} \
+   CONFIG.PSU__ENET3__PTP__ENABLE {0} \
+   CONFIG.PSU__ENET3__TSU__ENABLE {0} \
+   CONFIG.PSU__FPD_SLCR__WDT1__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__FPD_SLCR__WDT1__FREQMHZ {100.000000} \
+   CONFIG.PSU__FPD_SLCR__WDT_CLK_SEL__SELECT {APB} \
+   CONFIG.PSU__FPGA_PL0_ENABLE {1} \
+   CONFIG.PSU__FPGA_PL1_ENABLE {0} \
+   CONFIG.PSU__FPGA_PL2_ENABLE {0} \
+   CONFIG.PSU__FPGA_PL3_ENABLE {0} \
+   CONFIG.PSU__GEM3_COHERENCY {0} \
+   CONFIG.PSU__GEM3_ROUTE_THROUGH_FPD {0} \
+   CONFIG.PSU__GEM__TSU__ENABLE {0} \
+   CONFIG.PSU__GPIO0_MIO__IO {MIO 0 .. 25} \
+   CONFIG.PSU__GPIO0_MIO__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__GPIO1_MIO__IO {MIO 26 .. 51} \
+   CONFIG.PSU__GPIO1_MIO__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__GPIO2_MIO__IO {MIO 52 .. 77} \
+   CONFIG.PSU__GPIO2_MIO__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__GT__LINK_SPEED {HBR} \
+   CONFIG.PSU__GT__PRE_EMPH_LVL_4 {0} \
+   CONFIG.PSU__GT__VLT_SWNG_LVL_4 {0} \
+   CONFIG.PSU__HIGH_ADDRESS__ENABLE {0} \
+   CONFIG.PSU__I2C0__PERIPHERAL__ENABLE {0} \
+   CONFIG.PSU__I2C1__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__I2C1__PERIPHERAL__IO {MIO 4 .. 5} \
+   CONFIG.PSU__IOU_SLCR__IOU_TTC_APB_CLK__TTC0_SEL {APB} \
+   CONFIG.PSU__IOU_SLCR__IOU_TTC_APB_CLK__TTC1_SEL {APB} \
+   CONFIG.PSU__IOU_SLCR__IOU_TTC_APB_CLK__TTC2_SEL {APB} \
+   CONFIG.PSU__IOU_SLCR__IOU_TTC_APB_CLK__TTC3_SEL {APB} \
+   CONFIG.PSU__IOU_SLCR__TTC0__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__TTC0__FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__TTC1__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__TTC1__FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__TTC2__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__TTC2__FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__TTC3__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__TTC3__FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__WDT0__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__WDT0__FREQMHZ {100.000000} \
+   CONFIG.PSU__IOU_SLCR__WDT_CLK_SEL__SELECT {APB} \
+   CONFIG.PSU__LPD_SLCR__CSUPMU__ACT_FREQMHZ {100.000000} \
+   CONFIG.PSU__LPD_SLCR__CSUPMU__FREQMHZ {100.000000} \
+   CONFIG.PSU__MAXIGP0__DATA_WIDTH {128} \
+   CONFIG.PSU__MAXIGP1__DATA_WIDTH {128} \
+   CONFIG.PSU__MAXIGP2__DATA_WIDTH {32} \
+   CONFIG.PSU__OVERRIDE__BASIC_CLOCK {1} \
+   CONFIG.PSU__PL_CLK0_BUF {TRUE} \
+   CONFIG.PSU__PL_CLK1_BUF {FALSE} \
+   CONFIG.PSU__PL_CLK2_BUF {FALSE} \
+   CONFIG.PSU__PL_CLK3_BUF {FALSE} \
+   CONFIG.PSU__PMU_COHERENCY {0} \
+   CONFIG.PSU__PMU__AIBACK__ENABLE {0} \
+   CONFIG.PSU__PMU__EMIO_GPI__ENABLE {0} \
+   CONFIG.PSU__PMU__EMIO_GPO__ENABLE {0} \
+   CONFIG.PSU__PMU__GPI0__ENABLE {1} \
+   CONFIG.PSU__PMU__GPI0__IO {MIO 26} \
+   CONFIG.PSU__PMU__GPI1__ENABLE {0} \
+   CONFIG.PSU__PMU__GPI2__ENABLE {0} \
+   CONFIG.PSU__PMU__GPI3__ENABLE {0} \
+   CONFIG.PSU__PMU__GPI4__ENABLE {0} \
+   CONFIG.PSU__PMU__GPI5__ENABLE {0} \
+   CONFIG.PSU__PMU__GPO0__ENABLE {1} \
+   CONFIG.PSU__PMU__GPO0__IO {MIO 32} \
+   CONFIG.PSU__PMU__GPO1__ENABLE {1} \
+   CONFIG.PSU__PMU__GPO1__IO {MIO 33} \
+   CONFIG.PSU__PMU__GPO2__ENABLE {1} \
+   CONFIG.PSU__PMU__GPO2__IO {MIO 34} \
+   CONFIG.PSU__PMU__GPO2__POLARITY {high} \
+   CONFIG.PSU__PMU__GPO3__ENABLE {0} \
+   CONFIG.PSU__PMU__GPO4__ENABLE {0} \
+   CONFIG.PSU__PMU__GPO5__ENABLE {0} \
+   CONFIG.PSU__PMU__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__PMU__PLERROR__ENABLE {0} \
+   CONFIG.PSU__PRESET_APPLIED {1} \
+   CONFIG.PSU__PROTECTION__MASTERS {USB1:NonSecure;1|USB0:NonSecure;1|S_AXI_LPD:NA;0|S_AXI_HPC1_FPD:NA;0|S_AXI_HPC0_FPD:NA;0|S_AXI_HP3_FPD:NA;0|S_AXI_HP2_FPD:NA;0|S_AXI_HP1_FPD:NA;0|S_AXI_HP0_FPD:NA;0|S_AXI_ACP:NA;0|S_AXI_ACE:NA;0|SD1:NonSecure;1|SD0:NonSecure;1|SATA1:NonSecure;0|SATA0:NonSecure;0|RPU1:Secure;1|RPU0:Secure;1|QSPI:NonSecure;0|PMU:NA;1|PCIe:NonSecure;0|NAND:NonSecure;0|LDMA:NonSecure;1|GPU:NonSecure;1|GEM3:NonSecure;0|GEM2:NonSecure;0|GEM1:NonSecure;0|GEM0:NonSecure;0|FDMA:NonSecure;1|DP:NonSecure;1|DAP:NA;1|Coresight:NA;1|CSU:NA;1|APU:NA;1} \
+   CONFIG.PSU__PROTECTION__SLAVES { \
+     LPD;USB3_1_XHCI;FE300000;FE3FFFFF;1|LPD;USB3_1;FF9E0000;FF9EFFFF;1|LPD;USB3_0_XHCI;FE200000;FE2FFFFF;1|LPD;USB3_0;FF9D0000;FF9DFFFF;1|LPD;UART1;FF010000;FF01FFFF;1|LPD;UART0;FF000000;FF00FFFF;1|LPD;TTC3;FF140000;FF14FFFF;1|LPD;TTC2;FF130000;FF13FFFF;1|LPD;TTC1;FF120000;FF12FFFF;1|LPD;TTC0;FF110000;FF11FFFF;1|FPD;SWDT1;FD4D0000;FD4DFFFF;1|LPD;SWDT0;FF150000;FF15FFFF;1|LPD;SPI1;FF050000;FF05FFFF;1|LPD;SPI0;FF040000;FF04FFFF;1|FPD;SMMU_REG;FD5F0000;FD5FFFFF;1|FPD;SMMU;FD800000;FDFFFFFF;1|FPD;SIOU;FD3D0000;FD3DFFFF;1|FPD;SERDES;FD400000;FD47FFFF;1|LPD;SD1;FF170000;FF17FFFF;1|LPD;SD0;FF160000;FF16FFFF;1|FPD;SATA;FD0C0000;FD0CFFFF;0|LPD;RTC;FFA60000;FFA6FFFF;1|LPD;RSA_CORE;FFCE0000;FFCEFFFF;1|LPD;RPU;FF9A0000;FF9AFFFF;1|LPD;R5_TCM_RAM_GLOBAL;FFE00000;FFE3FFFF;1|LPD;R5_1_Instruction_Cache;FFEC0000;FFECFFFF;1|LPD;R5_1_Data_Cache;FFED0000;FFEDFFFF;1|LPD;R5_1_BTCM_GLOBAL;FFEB0000;FFEBFFFF;1|LPD;R5_1_ATCM_GLOBAL;FFE90000;FFE9FFFF;1|LPD;R5_0_Instruction_Cache;FFE40000;FFE4FFFF;1|LPD;R5_0_Data_Cache;FFE50000;FFE5FFFF;1|LPD;R5_0_BTCM_GLOBAL;FFE20000;FFE2FFFF;1|LPD;R5_0_ATCM_GLOBAL;FFE00000;FFE0FFFF;1|LPD;QSPI_Linear_Address;C0000000;DFFFFFFF;1|LPD;QSPI;FF0F0000;FF0FFFFF;0|LPD;PMU_RAM;FFDC0000;FFDDFFFF;1|LPD;PMU_GLOBAL;FFD80000;FFDBFFFF;1|FPD;PCIE_MAIN;FD0E0000;FD0EFFFF;0|FPD;PCIE_LOW;E0000000;EFFFFFFF;0|FPD;PCIE_HIGH2;8000000000;BFFFFFFFFF;0|FPD;PCIE_HIGH1;600000000;7FFFFFFFF;0|FPD;PCIE_DMA;FD0F0000;FD0FFFFF;0|FPD;PCIE_ATTRIB;FD480000;FD48FFFF;0|LPD;OCM_XMPU_CFG;FFA70000;FFA7FFFF;1|LPD;OCM_SLCR;FF960000;FF96FFFF;1|OCM;OCM;FFFC0000;FFFFFFFF;1|LPD;NAND;FF100000;FF10FFFF;0|LPD;MBISTJTAG;FFCF0000;FFCFFFFF;1|LPD;LPD_XPPU_SINK;FF9C0000;FF9CFFFF;1|LPD;LPD_XPPU;FF980000;FF98FFFF;1|LPD;LPD_SLCR_SECURE;FF4B0000;FF4DFFFF;1|LPD;LPD_SLCR;FF410000;FF4AFFFF;1|LPD;LPD_GPV;FE100000;FE1FFFFF;1|LPD;LPD_DMA_7;FFAF0000;FFAFFFFF;1|LPD;LPD_DMA_6;FFAE0000;FFAEFFFF;1|LPD;LPD_DMA_5;FFAD0000;FFADFFFF;1|LPD;LPD_DMA_4;FFAC0000;FFACFFFF;1|LPD;LPD_DMA_3;FFAB0000;FFABFFFF;1|LPD;LPD_DMA_2;FFAA0000;FFAAFFFF;1|LPD;LPD_DMA_1;FFA90000;FFA9FFFF;1|LPD;LPD_DMA_0;FFA80000;FFA8FFFF;1|LPD;IPI_CTRL;FF380000;FF3FFFFF;1|LPD;IOU_SLCR;FF180000;FF23FFFF;1|LPD;IOU_SECURE_SLCR;FF240000;FF24FFFF;1|LPD;IOU_SCNTRS;FF260000;FF26FFFF;1|LPD;IOU_SCNTR;FF250000;FF25FFFF;1|LPD;IOU_GPV;FE000000;FE0FFFFF;1|LPD;I2C1;FF030000;FF03FFFF;1|LPD;I2C0;FF020000;FF02FFFF;0|FPD;GPU;FD4B0000;FD4BFFFF;1|LPD;GPIO;FF0A0000;FF0AFFFF;1|LPD;GEM3;FF0E0000;FF0EFFFF;0|LPD;GEM2;FF0D0000;FF0DFFFF;0|LPD;GEM1;FF0C0000;FF0CFFFF;0|LPD;GEM0;FF0B0000;FF0BFFFF;0|FPD;FPD_XMPU_SINK;FD4F0000;FD4FFFFF;1|FPD;FPD_XMPU_CFG;FD5D0000;FD5DFFFF;1|FPD;FPD_SLCR_SECURE;FD690000;FD6CFFFF;1|FPD;FPD_SLCR;FD610000;FD68FFFF;1|FPD;FPD_DMA_CH7;FD570000;FD57FFFF;1|FPD;FPD_DMA_CH6;FD560000;FD56FFFF;1|FPD;FPD_DMA_CH5;FD550000;FD55FFFF;1|FPD;FPD_DMA_CH4;FD540000;FD54FFFF;1|FPD;FPD_DMA_CH3;FD530000;FD53FFFF;1|FPD;FPD_DMA_CH2;FD520000;FD52FFFF;1|FPD;FPD_DMA_CH1;FD510000;FD51FFFF;1|FPD;FPD_DMA_CH0;FD500000;FD50FFFF;1|LPD;EFUSE;FFCC0000;FFCCFFFF;1|FPD;Display Port;FD4A0000;FD4AFFFF;1|FPD;DPDMA;FD4C0000;FD4CFFFF;1|FPD;DDR_XMPU5_CFG;FD050000;FD05FFFF;1|FPD;DDR_XMPU4_CFG;FD040000;FD04FFFF;1|FPD;DDR_XMPU3_CFG;FD030000;FD03FFFF;1|FPD;DDR_XMPU2_CFG;FD020000;FD02FFFF;1|FPD;DDR_XMPU1_CFG;FD010000;FD01FFFF;1|FPD;DDR_XMPU0_CFG;FD000000;FD00FFFF;1|FPD;DDR_QOS_CTRL;FD090000;FD09FFFF;1|FPD;DDR_PHY;FD080000;FD08FFFF;1|DDR;DDR_LOW;0;7FFFFFFF;1|DDR;DDR_HIGH;800000000;800000000;0|FPD;DDDR_CTRL;FD070000;FD070FFF;1|LPD;Coresight;FE800000;FEFFFFFF;1|LPD;CSU_DMA;FFC80000;FFC9FFFF;1|LPD;CSU;FFCA0000;FFCAFFFF;1|LPD;CRL_APB;FF5E0000;FF85FFFF;1|FPD;CRF_APB;FD1A0000;FD2DFFFF;1|FPD;CCI_REG;FD5E0000;FD5EFFFF;1|LPD;CAN1;FF070000;FF07FFFF;0|LPD;CAN0;FF060000;FF06FFFF;0|FPD;APU;FD5C0000;FD5CFFFF;1|LPD;APM_INTC_IOU;FFA20000;FFA2FFFF;1|LPD;APM_FPD_LPD;FFA30000;FFA3FFFF;1|FPD;APM_5;FD490000;FD49FFFF;1|FPD;APM_0;FD0B0000;FD0BFFFF;1|LPD;APM2;FFA10000;FFA1FFFF;1|LPD;APM1;FFA00000;FFA0FFFF;1|LPD;AMS;FFA50000;FFA5FFFF;1|FPD;AFI_5;FD3B0000;FD3BFFFF;1|FPD;AFI_4;FD3A0000;FD3AFFFF;1|FPD;AFI_3;FD390000;FD39FFFF;1|FPD;AFI_2;FD380000;FD38FFFF;1|FPD;AFI_1;FD370000;FD37FFFF;1|FPD;AFI_0;FD360000;FD36FFFF;1|LPD;AFIFM6;FF9B0000;FF9BFFFF;1|FPD;ACPU_GIC;F9010000;F907FFFF;1 \
+   } \
+   CONFIG.PSU__PSS_REF_CLK__FREQMHZ {33.333333} \
+   CONFIG.PSU__QSPI_COHERENCY {0} \
+   CONFIG.PSU__QSPI_ROUTE_THROUGH_FPD {0} \
+   CONFIG.PSU__QSPI__GRP_FBCLK__ENABLE {0} \
+   CONFIG.PSU__QSPI__PERIPHERAL__ENABLE {0} \
+   CONFIG.PSU__SATA__LANE0__ENABLE {0} \
+   CONFIG.PSU__SATA__LANE1__ENABLE {0} \
+   CONFIG.PSU__SATA__PERIPHERAL__ENABLE {0} \
+   CONFIG.PSU__SD0_COHERENCY {0} \
+   CONFIG.PSU__SD0_ROUTE_THROUGH_FPD {0} \
+   CONFIG.PSU__SD0__DATA_TRANSFER_MODE {4Bit} \
+   CONFIG.PSU__SD0__GRP_CD__ENABLE {1} \
+   CONFIG.PSU__SD0__GRP_CD__IO {MIO 24} \
+   CONFIG.PSU__SD0__GRP_POW__ENABLE {0} \
+   CONFIG.PSU__SD0__GRP_WP__ENABLE {0} \
+   CONFIG.PSU__SD0__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__SD0__PERIPHERAL__IO {MIO 13 .. 16 21 22} \
+   CONFIG.PSU__SD0__RESET__ENABLE {0} \
+   CONFIG.PSU__SD0__SLOT_TYPE {SD 2.0} \
+   CONFIG.PSU__SD1_COHERENCY {0} \
+   CONFIG.PSU__SD1_ROUTE_THROUGH_FPD {0} \
+   CONFIG.PSU__SD1__DATA_TRANSFER_MODE {4Bit} \
+   CONFIG.PSU__SD1__GRP_CD__ENABLE {0} \
+   CONFIG.PSU__SD1__GRP_POW__ENABLE {0} \
+   CONFIG.PSU__SD1__GRP_WP__ENABLE {0} \
+   CONFIG.PSU__SD1__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__SD1__PERIPHERAL__IO {MIO 46 .. 51} \
+   CONFIG.PSU__SD1__RESET__ENABLE {0} \
+   CONFIG.PSU__SD1__SLOT_TYPE {SD 2.0} \
+   CONFIG.PSU__SPI0__GRP_SS0__ENABLE {1} \
+   CONFIG.PSU__SPI0__GRP_SS0__IO {MIO 41} \
+   CONFIG.PSU__SPI0__GRP_SS1__ENABLE {0} \
+   CONFIG.PSU__SPI0__GRP_SS2__ENABLE {0} \
+   CONFIG.PSU__SPI0__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__SPI0__PERIPHERAL__IO {MIO 38 .. 43} \
+   CONFIG.PSU__SPI1__GRP_SS0__ENABLE {1} \
+   CONFIG.PSU__SPI1__GRP_SS0__IO {MIO 9} \
+   CONFIG.PSU__SPI1__GRP_SS1__ENABLE {0} \
+   CONFIG.PSU__SPI1__GRP_SS2__ENABLE {0} \
+   CONFIG.PSU__SPI1__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__SPI1__PERIPHERAL__IO {MIO 6 .. 11} \
+   CONFIG.PSU__SWDT0__CLOCK__ENABLE {0} \
+   CONFIG.PSU__SWDT0__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__SWDT0__RESET__ENABLE {0} \
+   CONFIG.PSU__SWDT1__CLOCK__ENABLE {0} \
+   CONFIG.PSU__SWDT1__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__SWDT1__RESET__ENABLE {0} \
+   CONFIG.PSU__TSU__BUFG_PORT_PAIR {0} \
+   CONFIG.PSU__TTC0__CLOCK__ENABLE {0} \
+   CONFIG.PSU__TTC0__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__TTC0__WAVEOUT__ENABLE {0} \
+   CONFIG.PSU__TTC1__CLOCK__ENABLE {0} \
+   CONFIG.PSU__TTC1__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__TTC1__WAVEOUT__ENABLE {0} \
+   CONFIG.PSU__TTC2__CLOCK__ENABLE {0} \
+   CONFIG.PSU__TTC2__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__TTC2__WAVEOUT__ENABLE {0} \
+   CONFIG.PSU__TTC3__CLOCK__ENABLE {0} \
+   CONFIG.PSU__TTC3__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__TTC3__WAVEOUT__ENABLE {0} \
+   CONFIG.PSU__UART0__BAUD_RATE {115200} \
+   CONFIG.PSU__UART0__MODEM__ENABLE {0} \
+   CONFIG.PSU__UART0__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__UART0__PERIPHERAL__IO {MIO 2 .. 3} \
+   CONFIG.PSU__UART1__BAUD_RATE {115200} \
+   CONFIG.PSU__UART1__MODEM__ENABLE {0} \
+   CONFIG.PSU__UART1__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__UART1__PERIPHERAL__IO {MIO 0 .. 1} \
+   CONFIG.PSU__USB0_COHERENCY {0} \
+   CONFIG.PSU__USB0__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__USB0__PERIPHERAL__IO {MIO 52 .. 63} \
+   CONFIG.PSU__USB0__REF_CLK_FREQ {26} \
+   CONFIG.PSU__USB0__REF_CLK_SEL {Ref Clk0} \
+   CONFIG.PSU__USB0__RESET__ENABLE {0} \
+   CONFIG.PSU__USB1_COHERENCY {0} \
+   CONFIG.PSU__USB1__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__USB1__PERIPHERAL__IO {MIO 64 .. 75} \
+   CONFIG.PSU__USB1__REF_CLK_FREQ {26} \
+   CONFIG.PSU__USB1__REF_CLK_SEL {Ref Clk0} \
+   CONFIG.PSU__USB1__RESET__ENABLE {0} \
+   CONFIG.PSU__USB2_0__EMIO__ENABLE {0} \
+   CONFIG.PSU__USB2_1__EMIO__ENABLE {0} \
+   CONFIG.PSU__USB3_0__EMIO__ENABLE {0} \
+   CONFIG.PSU__USB3_0__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__USB3_0__PERIPHERAL__IO {GT Lane2} \
+   CONFIG.PSU__USB3_1__EMIO__ENABLE {0} \
+   CONFIG.PSU__USB3_1__PERIPHERAL__ENABLE {1} \
+   CONFIG.PSU__USB3_1__PERIPHERAL__IO {GT Lane3} \
+   CONFIG.PSU__USB__RESET__MODE {Boot Pin} \
+   CONFIG.PSU__USB__RESET__POLARITY {Active Low} \
+   CONFIG.PSU__USE__IRQ0 {1} \
+   CONFIG.PSU__USE__M_AXI_GP0 {0} \
+   CONFIG.PSU__USE__M_AXI_GP1 {0} \
+   CONFIG.PSU__USE__M_AXI_GP2 {0} \
+   CONFIG.SUBPRESET1 {Custom} \
+ ] $zynq_ultra_ps_e_0
+
+  # Create port connections
+  connect_bd_net -net zynq_ultra_ps_e_0_pl_clk0 [get_bd_ports pl_clk0_0] [get_bd_pins zynq_ultra_ps_e_0/pl_clk0]
+
+  # Create address segments
+
+
+  # Restore current instance
+  current_bd_instance $oldCurInst
+
+  validate_bd_design
+  save_bd_design
+}
+# End of create_root_design()
+
+
+##################################################################
+# MAIN FLOW
+##################################################################
+
+create_root_design ""
+
+

--- a/ultra96_v2/blinky.xdc
+++ b/ultra96_v2/blinky.xdc
@@ -1,0 +1,5 @@
+## Clock signal
+# ultra96_v2 has no on-board PL clock so use clk generated from PS, see block diagram 
+
+## LED
+set_property -dict { PACKAGE_PIN A9 IOSTANDARD LVCMOS18 } [get_ports q];

--- a/ultra96_v2/blinky_ultra96_v2.v
+++ b/ultra96_v2/blinky_ultra96_v2.v
@@ -1,0 +1,35 @@
+`timescale 1ns / 1ps
+//////////////////////////////////////////////////////////////////////////////////
+// Company: 
+// Engineer: 
+// 
+// Create Date: 10/29/2021 09:35:40 PM
+// Design Name: 
+// Module Name: blinky_ultra96_v2
+// Project Name: 
+// Target Devices: 
+// Tool Versions: 
+// Description: 
+// 
+// Dependencies: 
+// 
+// Revision:
+// Revision 0.01 - File Created
+// Additional Comments:
+// 
+//////////////////////////////////////////////////////////////////////////////////
+
+
+module blinky_ultra96_v2
+  (output wire q);
+  
+  wire clk;
+
+  blinky #(.clk_freq_hz (100_000_000)) blinky_i
+    (.clk(clk),
+     .q(q));
+      
+  design_1_wrapper design_1_wrapper_i
+    (.pl_clk0_0(clk));
+
+endmodule

--- a/ultra96_v2/design_1_wrapper.v
+++ b/ultra96_v2/design_1_wrapper.v
@@ -1,0 +1,20 @@
+//Copyright 1986-2020 Xilinx, Inc. All Rights Reserved.
+//--------------------------------------------------------------------------------
+//Tool Version: Vivado v.2020.2 (lin64) Build 3064766 Wed Nov 18 09:12:47 MST 2020
+//Date        : Fri Oct 29 22:07:36 2021
+//Host        : cloud running 64-bit Ubuntu 18.04.6 LTS
+//Command     : generate_target design_1_wrapper.bd
+//Design      : design_1_wrapper
+//Purpose     : IP block netlist
+//--------------------------------------------------------------------------------
+`timescale 1 ps / 1 ps
+
+module design_1_wrapper
+   (pl_clk0_0);
+  output pl_clk0_0;
+
+  wire pl_clk0_0;
+
+  design_1 design_1_i
+       (.pl_clk0_0(pl_clk0_0));
+endmodule


### PR DESCRIPTION
PL clock is supplied from PS. Block design tcl is used for that.
Block design tcl file is exported from Vivado 2020.2.

Similar flow could be applied to microzed and zynqberry boards which also do not have on-board PL clock source.