### PR TITLE
Arrow BeMicro MAX 10 board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ https://alhambrabits.com/alhambra/
 
 https://store.digilentinc.com/arty-a7-artix-7-fpga-development-board-for-makers-and-hobbyists/
 
+### bemicro_max10
+
+https://www.arrow.com/en/products/bemicromax10/arrow-development-tools
+
 ### cmod_a7
 
 This are two variants for this board:

--- a/bemicro_max10/bemicro_max10.sdc
+++ b/bemicro_max10/bemicro_max10.sdc
@@ -1,0 +1,8 @@
+# Main system clock (12 Mhz)
+create_clock -name "clk" -period 20ns [get_ports {clk}]
+
+# Automatically constrain PLL and other generated clocks
+derive_pll_clocks -create_base_clocks
+
+# Automatically calculate clock uncertainty to jitter and other effects.
+derive_clock_uncertainty

--- a/bemicro_max10/pinmap.tcl
+++ b/bemicro_max10/pinmap.tcl
@@ -1,0 +1,11 @@
+#
+# Clock / Reset
+#
+set_location_assignment PIN_N14 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to clk
+
+#
+# GPIO0
+#
+set_location_assignment PIN_M2 -to q
+set_instance_assignment -name IO_STANDARD "3.3-V LVTTL" -to q

--- a/blinky.core
+++ b/blinky.core
@@ -41,6 +41,11 @@ filesets:
   basys3:
     files: [basys3/blinky.xdc : {file_type : xdc}]
 
+  bemicro_max10:
+    files:
+      - bemicro_max10/bemicro_max10.sdc : {file_type : SDC}
+      - bemicro_max10/pinmap.tcl  	: {file_type: tclSource}
+
   c10lp_refkit:
     files:
       - c10lp_refkit/c10lp_refkit.sdc : {file_type: SDC}
@@ -242,7 +247,7 @@ filesets:
 
   tinyfpga_bx:
     files: [tinyfpga_bx/pinout.pcf : {file_type : PCF}]
-  
+
   ultra96_v2:
     files:
       - ultra96_v2/blinky_ultra96_v2.v : {file_type : verilogSource}
@@ -427,6 +432,17 @@ targets:
       vivado:
         part : xc7a35tcpg236-1
     toplevel : blinky
+
+  bemicro_max10:
+    <<: *default
+    default_tool : quartus
+    description: Arrow BeMicro MAX 10
+    filesets_append : [bemicro_max10]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : MAX 10
+        device : 10M08DAF484C8GES
 
   c10lp_refkit:
     <<: *default


### PR DESCRIPTION
Support added for  Arrow BeMicro MAX10 board (equipped with Altera/Intel 10M08 FPGA).