### PR TITLE
Add digilent Arty A7 100t support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ The cores for the Cu are built using IceStorm, and the cores for the Au and Au+ 
 
 https://alhambrabits.com/alhambra/
 
-### arty_a7_35t
+### arty_a7_35t/arty_a7_100t
 
-https://store.digilentinc.com/arty-a7-artix-7-fpga-development-board-for-makers-and-hobbyists/
+https://digilent.com/shop/arty-a7-artix-7-fpga-development-board/
 
 ### ax309
 

--- a/arty_a7_100t/blinky.xdc
+++ b/arty_a7_100t/blinky.xdc
@@ -1,0 +1,6 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN E3    IOSTANDARD LVCMOS33 } [get_ports { clk }]; #IO_L12P_T1_MRCC_35 Sch=gclk[100]
+create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports { clk }];
+
+## LED
+set_property -dict { PACKAGE_PIN H5    IOSTANDARD LVCMOS33 } [get_ports { q }]; #IO_L24N_T3_35 Sch=led[4]

--- a/blinky.core
+++ b/blinky.core
@@ -50,6 +50,9 @@ filesets:
   arty_a7_35t:
     files: [arty_a7_35t/blinky.xdc : {file_type : xdc}]
 
+  arty_a7_100t:
+    files: [arty_a7_100t/blinky.xdc : {file_type : xdc}]
+
   arty_s7_50t:
     files: [arty_s7_50t/blinky.xdc : {file_type : xdc}]
 
@@ -485,6 +488,15 @@ targets:
     tools:
       vivado:
         part : xc7a35ticsg324-1L
+    toplevel : blinky
+
+  arty_a7_100t:
+    default_tool : vivado
+    filesets : [rtl, arty_a7_100t]
+    parameters : [clk_freq_hz=100000000]
+    tools:
+      vivado:
+        part : xc7a100tcsg324-1
     toplevel : blinky
 
   arty_s7_50t:


### PR DESCRIPTION
I added support for the digilent Arty A7 100t board and was able to successfully program the board (using fusesoc).
Please consider merging these changes.