### PR TITLE
Add support for ICE-V Wireless board

### DIFF
--- a/blinky.core
+++ b/blinky.core
@@ -190,6 +190,9 @@ filesets:
   icebreaker:
     files: [icebreaker/pinout.pcf : {file_type : PCF}]
 
+  icev_wireless:
+    files: [icev_wireless/pinout.pcf : {file_type : PCF}]
+
   iceFUN:
     files:
       - iceFUN/blinky.v : {file_type : verilogSource}
@@ -867,6 +870,18 @@ targets:
   icebreaker:
     default_tool : icestorm
     filesets : [rtl, proginfo, icebreaker]
+    hooks:
+      post_run: [iceprog]
+    parameters : [clk_freq_hz=12000000]
+    tools:
+      icestorm:
+        nextpnr_options: [--up5k, --package, sg48]
+        pnr: next
+    toplevel : blinky
+
+  icev_wireless:
+    default_tool : icestorm
+    filesets : [rtl, proginfo, icev_wireless]
     hooks:
       post_run: [iceprog]
     parameters : [clk_freq_hz=12000000]

--- a/icev_wireless/pinout.pcf
+++ b/icev_wireless/pinout.pcf
@@ -1,0 +1,4 @@
+set_io clk 35
+
+# use q values: 39 = red, 40 = green, 41 = blue
+set_io q 40


### PR DESCRIPTION
This PR adds support for the new [ICE-V Wireless](https://github.com/ICE-V-Wireless/ICE-V-Wireless) board.

The iCEBreaker was used as an example.

Note programming requires [firmware](https://github.com/ICE-V-Wireless/ICE-V-Wireless/tree/main/Firmware) loaded onto the ESP32 and binary upload with [send_c3sock.py](https://github.com/ICE-V-Wireless/ICE-V-Wireless/blob/main/python/send_c3sock.py)

For example, assuming the ICE-V Wireless is at `192.168.1.28`, from the FuseSoC blinky project directory:

```
python3 ../ICE-V-Wireless/python/send_c3sock.py -a 192.168.1.28 --flash ./build/fusesoc_utils_blinky_1.1.1/icev_wireless-icestorm/fusesoc_utils_blinky_1.1.1.bin
```