### PR TITLE
Use * to support any version

### DIFF
--- a/sw/proginfo.py
+++ b/sw/proginfo.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-system_name = "fusesoc_utils_blinky_1.0"
+system_name = "fusesoc_utils_blinky_*"
 print("")
 print("Build was completed")
 print("")


### PR DESCRIPTION
I was doing blinky 1.1 and this command was wrong.