### PR TITLE
Add support for Xilinx Spartan-3A(N) FPGA Starter Kit (up to bitgen f…

### DIFF
--- a/blinky.core
+++ b/blinky.core
@@ -273,6 +273,11 @@ filesets:
      - qmtech_5cefa5f23/blinky_qmtech_5cefa5f23.v : {file_type : verilogSource }
      - qmtech_5cefa5f23/io.qsf : {file_type : QSF}
 
+  spartan3a_starter_kit:
+    files:
+      - spartan3a_starter_kit/blinky.ucf : {file_type : UCF}
+      - spartan3a_starter_kit/options.tcl : {file_type : tclSource}
+
   spartan_edge_accelerator_board:
     files: [spartan_edge_accelerator_board/blinky.xdc : {file_type : xdc}]
 
@@ -1078,6 +1083,34 @@ targets:
       xsim:
         xelab_options: [--timescale, 1ns/1ns]
     toplevel: blinky_tb
+
+  spartan3a_starter_kit:
+    default_tool : ise
+    description : XILINX Spartan-3A FPGA Starter Kit
+    filesets : [rtl, spartan3a_starter_kit]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      ise:
+        family  : "\"Spartan3A and Spartan3AN\""
+        device  : xc3s700a
+        package : fgg484
+        speed   : -4
+        board_device_index : 1
+    toplevel : blinky
+
+  spartan3an_starter_kit:
+    default_tool : ise
+    description : XILINX Spartan-3AN FPGA Starter Kit
+    filesets : [rtl, spartan3a_starter_kit]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      ise:
+        family  : "\"Spartan3A and Spartan3AN\""
+        device  : xc3s700an
+        package : fgg484
+        speed   : -4
+        board_device_index : 1
+    toplevel : blinky
 
   spartan_edge_accelerator_board:
     default_tool : vivado

--- a/spartan3a_starter_kit/blinky.ucf
+++ b/spartan3a_starter_kit/blinky.ucf
@@ -1,0 +1,8 @@
+# UCF Location Constraints for 50 MHz Clock Source
+NET "clk" LOC = "E12" | IOSTANDARD = LVCMOS33 ;
+
+# Define clock period for 50 MHz oscillator
+NET "clk" PERIOD = 20.0ns HIGH 50%;
+
+# UCF Constraints for a discrete LED
+NET "q" LOC = "R20" | IOSTANDARD = LVCMOS33 | SLEW = SLOW | DRIVE = 8 ;

--- a/spartan3a_starter_kit/options.tcl
+++ b/spartan3a_starter_kit/options.tcl
@@ -1,0 +1,1 @@
+project set "Other XST Command Line Options" "-use_new_parser yes"


### PR DESCRIPTION
…or now)

Issues (all related to edalize):

1. The device family for Spartan3A(N) is named "Spartan3A and Spartan3AN" which have spaces. Edalize does not yet emit `{family}` with quotes so without escaping the double quotes inside the quoted string, there will be _multiple argument_ error.

2. I can only program the FPGA if, within the generated pgm file, I add the switch `-onlyFpga` on the `program` command. Suggest to add parameter `program_args` to allow arbitrary switches to be specified.