### PR TITLE
adding A-C4E6E10

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Board support
 
 The following boards are currently supported:
 
+### A-C4E6E1 Cyclone IV FPGA EP4CE6E22C8N Development Board
+
+http://land-boards.com/blwiki/index.php?title=A-C4E6_Cyclone_IV_FPGA_EP4CE6E22C8N_Development_Board
+
 ### AC701
 
 https://www.xilinx.com/products/boards-and-kits/ek-a7-ac701-g.html

--- a/a_c4e6e10/a_c4e6e10.tcl
+++ b/a_c4e6e10/a_c4e6e10.tcl
@@ -1,0 +1,27 @@
+set_global_assignment -name ERROR_CHECK_FREQUENCY_DIVISOR 256
+set_global_assignment -name EDA_SIMULATION_TOOL "Questa Intel FPGA (Verilog)"
+set_global_assignment -name EDA_TIME_SCALE "1 ps" -section_id eda_simulation
+set_global_assignment -name EDA_OUTPUT_DATA_FORMAT "VERILOG HDL" -section_id eda_simulation
+
+# Clock
+set_location_assignment PIN_23 -to clk
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to clk
+
+# User LEDs
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to leds[0]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to leds[1]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to leds[2]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to leds[3]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to leds[4]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to leds[5]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to leds[6]
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to leds[7]
+
+set_location_assignment PIN_76 -to leds[7]
+set_location_assignment PIN_77 -to leds[6]
+set_location_assignment PIN_84 -to leds[5]
+set_location_assignment PIN_83 -to leds[4]
+set_location_assignment PIN_80 -to leds[3]
+set_location_assignment PIN_74 -to leds[2]
+set_location_assignment PIN_73 -to leds[1]
+set_location_assignment PIN_72 -to leds[0]

--- a/a_c4e6e10/blinky_a_c4e6e10.sv
+++ b/a_c4e6e10/blinky_a_c4e6e10.sv
@@ -1,0 +1,20 @@
+module blinky_a_c4e6e10 #(
+    parameter clk_freq_hz = 50000000
+) (
+    input clk,
+    output wire [7:0] leds
+);
+
+
+  wire led;
+  genvar i;
+
+  assign leds = {8{led}};
+
+  blinky #(
+      .clk_freq_hz(clk_freq_hz)
+  ) b (
+      .clk(clk),
+      .q  (led)
+  );
+endmodule

--- a/blinky.core
+++ b/blinky.core
@@ -2,6 +2,11 @@ CAPI=2:
 name : fusesoc:utils:blinky:1.1.1
 
 filesets:
+  a_c4e6e10:
+    files:
+      - a_c4e6e10/blinky_a_c4e6e10.sv : {file_type : systemVerilogSource}
+      - a_c4e6e10/a_c4e6e10.tcl : {file_type : tclSource}
+      
   ac701:
     files:
       - ac701/blinky_ac701.v : {file_type : verilogSource}
@@ -469,6 +474,16 @@ targets:
   default: &default
     filesets : [rtl]
     toplevel: ["is_toplevel? (blinky)"]
+
+  a_c4e6e10:
+    default_tool : quartus
+    filesets : [rtl, a_c4e6e10]
+    parameters : [clk_freq_hz=50000000]
+    tools:
+      quartus:
+        family : Cyclone IV E
+        device : EP4CE6E22C8
+    toplevel: blinky_a_c4e6e10
 
   ac701:
     default_tool: vivado


### PR DESCRIPTION
Adding support for A-C4E6E10 Cyclone IV FPGA EP4CE6E22C8N Development Board
Mostly _"inspired"_ (copied) from #106.