### PR TITLE
Add support for iCESugar-nano board

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,18 @@ https://www.crowdsupply.com/1bitsquared/icebreaker-fpga
 
 https://www.robot-electronics.co.uk/products/fpga/icefun.html
 
+### iCESugar
+
+[MuseLab交流群 homepage](https://www.muselab-tech.com/wan-quan-shi-yong-kai-yuan-gong-ju-lian-de-fpgadan-ban/)\
+[Shop](https://www.aliexpress.com/item/4001201771358.html)\
+[GitHub examples](https://github.com/wuxx/icesugar/)
+
+### iCESugar-nano
+
+[MuseLab交流群 homepage](https://www.muselab-tech.com/icesugar-nano-kai-yuan-fpgakai-fa-ban/)\
+[Shop](https://www.aliexpress.com/item/1005002073816863.html)\
+[GitHub examples](https://github.com/wuxx/icesugar-nano)
+
 ### iceWerx
 
 https://www.robot-electronics.co.uk/icewerx.html

--- a/blinky.core
+++ b/blinky.core
@@ -234,6 +234,10 @@ filesets:
       - icesugar/blinky.v : {file_type : verilogSource}
       - icesugar/icesugar.pcf : {file_type : PCF}
 
+  icesugar_nano:
+    files:
+      - icesugar_nano/icesugar-nano.pcf : {file_type : PCF}
+
   iceWerx:
     files: [iceWerx/pinout.pcf : {file_type : PCF}]
 
@@ -1080,6 +1084,19 @@ targets:
         nextpnr_options : [--up5k, --package, sg48]
         pnr : next
     toplevel : Top
+
+  icesugar_nano:
+    default_tool : icestorm
+    description : iCESugar-nano board
+    filesets : [rtl, proginfo, icesugar_nano]
+    parameters : [clk_freq_hz=12000000]
+    hooks:
+      post_run: [icesprog]
+    tools:
+       icestorm:
+        nextpnr_options : [--lp1k, --package, cm36]
+        pnr : next
+    toplevel : blinky
 
   iceWerx:
     default_tool : icestorm

--- a/icesugar_nano/icesugar-nano.pcf
+++ b/icesugar_nano/icesugar-nano.pcf
@@ -1,0 +1,5 @@
+# Icesugar-nano board
+
+set_io clk D1
+
+set_io q B6


### PR DESCRIPTION
Use the default blinky RTL code and the open source toolchain.