### PR TITLE
Add: support added for EDGE Zynq7020 by Invent Logics

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,15 @@ https://github.com/xjtuecho/EBAZ4205
 
 https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/ECP5EvaluationBoard
 
+### EDGE ZYNQ SoC FPGA Development Board - edgeZ7_20
+
+EDGE ZYNQ SoC FPGA Development Board is a feature rich and high-performance Single Board Computer built around the Xilinx Zynq-7010 (XC7Z010) or Zynq-7020 (XC7Z020). It features integrated dual-core ARM Cortex-A9 processor with Xilinx 7-series FPGA.
+
+Part Number : XC7Z020-1CLG400C
+
+https://allaboutfpga.com/product/edge-zynq-soc-fpga-development-board/
+https://github.com/AllAboutFPGA/EDGE-FPGA-Kit-Board-Files/tree/master/edgeZ7_20/A.0
+
 ### EP2C5T144 Development Board
 
 http://land-boards.com/blwiki/index.php?title=Cyclone_II_EP2C5_Mini_Dev_Board

--- a/blinky.core
+++ b/blinky.core
@@ -325,6 +325,11 @@ filesets:
       - pynq_z2/blinky_pynq_z2.v : {file_type : verilogSource}
       - pynq_z2/blinky.xdc : {file_type : xdc}
 
+  edgeZ7_20:
+    files:
+      - edgeZ7_20/blinky_edgeZ7_20.v : {file_type : verilogSource}
+      - edgeZ7_20/blinky.xdc : {file_type : xdc}
+
   qmtech_5cefa5f23:
     files:
      - qmtech_5cefa5f23/blinky_qmtech_5cefa5f23.v : {file_type : verilogSource }
@@ -1291,6 +1296,15 @@ targets:
       vivado:
         part : xc7z020clg400-1
     toplevel : blinky_pynq_z2
+
+  edgeZ7_20:
+    default_tool: vivado
+    description : EdgeZ7-20 Zynq Z7020 Development Board
+    filesets : [rtl, edgeZ7_20]
+    tools:
+      vivado:
+        part : xc7z020clg400-1
+    toplevel : blinky_edgeZ7_20
 
   qmtech_5cefa5f23:
     default_tool : mistral

--- a/edgeZ7_20/blinky.xdc
+++ b/edgeZ7_20/blinky.xdc
@@ -1,0 +1,6 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN U18 IOSTANDARD LVCMOS33 } [get_ports clk];
+create_clock -add -name sys_clk_pin -period 8 -waveforem {0 4} [get_nets clk];
+
+## LED
+set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports q];

--- a/edgeZ7_20/blinky_edgeZ7_20.v
+++ b/edgeZ7_20/blinky_edgeZ7_20.v
@@ -1,0 +1,11 @@
+module blinky_edgeZ7_20
+  (input wire  clk,
+   output wire q);
+
+   wire        clk;
+
+   blinky #(.clk_freq_hz (125_000_000)) blinky
+     (.clk (clk),
+      .q   (q));
+
+endmodule


### PR DESCRIPTION
Hi team,

This PR adds support for the Edge Zynq SoC (Zynq 7020) development board by [Invent Logics (allaboutfpga.com)](https://allaboutfpga.com/).

Changes include:

- Blinky project support for the Edge Zynq board
- Necessary source/configuration file updates
- README updated with relevant board information and usage instructions

Please review and let me know if any changes or improvements are required.

Thank you! 🙌

Best regards,
vadakkodan(Pradeep)