### PR TITLE
Added support for Lattice iCE40 UltraPlus breakout board

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ https://www.olimex.com/wiki/ICE40HX1K-EVB
 
 http://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/iCE40HX8KBreakoutBoard.aspx
 
+### ice40-up5k_breakout
+
+https://www.latticesemi.com/products/developmentboardsandkits/ice40ultraplusbreakoutboard
+
 ### iCEBreaker FPGA
 
 https://www.crowdsupply.com/1bitsquared/icebreaker-fpga

--- a/blinky.core
+++ b/blinky.core
@@ -233,6 +233,9 @@ filesets:
   ice40-hx8k_breakout:
     files: [ice40-hx8k_breakout/pinout.pcf : {file_type : PCF}]
 
+  ice40-up5k_breakout:
+    files: [ice40-up5k_breakout/pinout.pcf : {file_type : PCF}]
+
   icebreaker:
     files: [icebreaker/pinout.pcf : {file_type : PCF}]
 
@@ -1091,6 +1094,16 @@ targets:
     tools:
       icestorm:
         nextpnr_options : [--hx8k, --package, ct256]
+        pnr : next
+    toplevel : blinky
+
+  ice40-up5k_breakout:
+    default_tool : icestorm
+    filesets : [rtl, proginfo, ice40-up5k_breakout]
+    parameters : [clk_freq_hz=12000000]
+    tools:
+      icestorm:
+        nextpnr_options : [--up5k, --package, sg48]
         pnr : next
     toplevel : blinky
 

--- a/ice40-up5k_breakout/pinout.pcf
+++ b/ice40-up5k_breakout/pinout.pcf
@@ -1,0 +1,2 @@
+set_io clk 35    # 12 Mhz clock 
+set_io q 39      # LED (blue)


### PR DESCRIPTION
The following changes were made to add support for the Lattice iCE40 UltraPlus breakout board:

- Added board fileset and run target to blinky.core
- Added board constraint file in ice40-up5k_breakout folder
- Added board name and hyperlink to README