### PR TITLE
feat: add support for the Alinx AX7A200B board

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,17 @@ The cores for the Cu are built using IceStorm, and the cores for the Au and Au+ 
 
 https://alhambrabits.com/alhambra/
 
+### Alinx AX7A200B
+
+https://www.en.alinx.com/Product/FPGA-Development-Boards/Artix-7/AX7A200B.html
+
 ### arty_a7_35t/arty_a7_100t
 
 https://digilent.com/shop/arty-a7-artix-7-fpga-development-board/
 
 ### Atum A3 Nano (Terasic)
 
-https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&No=1373 
+https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&No=1373
 
 ### ax309
 
@@ -104,7 +108,7 @@ http://www.alinx.com/en/index.php/default/content/143.html
 
 ### AXE5000 (Arrow)
 
-https://github.com/ArrowElectronics/Agilex-5/wiki/Agilex-5-E-Series-AXE5000-Development-Platform 
+https://github.com/ArrowElectronics/Agilex-5/wiki/Agilex-5-E-Series-AXE5000-Development-Platform
 
 ### axku5
 
@@ -317,11 +321,11 @@ https://www.latticesemi.com/products/developmentboardsandkits/machxo3lfstarterki
 
 ### max10_10m08evk
 
-https://www.intel.com/content/www/us/en/products/details/fpga/development-kits/max/10m08-evaluation-kit.html 
+https://www.intel.com/content/www/us/en/products/details/fpga/development-kits/max/10m08-evaluation-kit.html
 
 ### max10_10m50evk
 
-https://www.intel.com/content/www/us/en/products/details/fpga/development-kits/max/10m50-evaluation-kit.html 
+https://www.intel.com/content/www/us/en/products/details/fpga/development-kits/max/10m50-evaluation-kit.html
 
 ### max1000
 
@@ -384,9 +388,9 @@ https://github.com/ChinaQMTECH/QM_CYCLONE_V/tree/master/5CEFA5F23
 This example use [mistral toolchain](https://github.com/Ravenslofty/mistral)
 
 ### QMTECH Wukong Board Artix-7 XC7A100T & XC7A200T
-The Wukong board have two revisions : [Artix-7 XC7A100T](https://github.com/ChinaQMTECH/QM_XC7A100T_WUKONG_BOARD/blob/master/QMTECH_Artix-7_XC7A100T_Wukong_Board_User_Manual(Hardware)_V01.pdf) and Artix-7 XC7A[100T](https://github.com/ChinaQMTECH/XC7A100T-200T_Wukong_Board/blob/main/User_Manual_XC7A100T/QMTECH_Artix-7_XC7A100T_Wukong_Board_V2_User_Manual(Hardware)_V01.pdf)-[200T](https://github.com/ChinaQMTECH/XC7A100T-200T_Wukong_Board/blob/main/User_Manual_XC7A200T/QMTECH_Artix-7_XC7A200T_Wukong_Board_V2_User_Manual(Hardware)_V01.pdf) . The first revision have the 50 MHz clock on the wrong pin and don't have micro sd. 
+The Wukong board have two revisions : [Artix-7 XC7A100T](https://github.com/ChinaQMTECH/QM_XC7A100T_WUKONG_BOARD/blob/master/QMTECH_Artix-7_XC7A100T_Wukong_Board_User_Manual(Hardware)_V01.pdf) and Artix-7 XC7A[100T](https://github.com/ChinaQMTECH/XC7A100T-200T_Wukong_Board/blob/main/User_Manual_XC7A100T/QMTECH_Artix-7_XC7A100T_Wukong_Board_V2_User_Manual(Hardware)_V01.pdf)-[200T](https://github.com/ChinaQMTECH/XC7A100T-200T_Wukong_Board/blob/main/User_Manual_XC7A200T/QMTECH_Artix-7_XC7A200T_Wukong_Board_V2_User_Manual(Hardware)_V01.pdf) . The first revision have the 50 MHz clock on the wrong pin and don't have micro sd.
 
-Targets are `Wukong_v1` for revision 1 , `Wukong_100t_v2` and `Wukong_200t_v2` for revision 2. Those boards can be programmed with openFPGALoader.  
+Targets are `Wukong_v1` for revision 1 , `Wukong_100t_v2` and `Wukong_200t_v2` for revision 2. Those boards can be programmed with openFPGALoader.
 
 ### RZ-EasyFPGA A2.x
 

--- a/alinx_ax7a200b/blinky.xdc
+++ b/alinx_ax7a200b/blinky.xdc
@@ -1,0 +1,8 @@
+## Clock signal
+set_property -dict { PACKAGE_PIN R4 IOSTANDARD DIFF_SSTL15 } [get_ports sys_clk_p];
+set_property -dict { PACKAGE_PIN T4 IOSTANDARD DIFF_SSTL15 } [get_ports sys_clk_n];
+
+create_clock -name clk_p -period 5.0 [get_nets sys_clk_p]
+
+## LED
+set_property -dict { PACKAGE_PIN L13 IOSTANDARD LVCMOS33 } [get_ports q]

--- a/alinx_ax7a200b/blinky_alinx_ax7a200b.v
+++ b/alinx_ax7a200b/blinky_alinx_ax7a200b.v
@@ -1,0 +1,22 @@
+module blinky_alinx_ax7a200b (
+  input wire  sys_clk_p,
+  input wire  sys_clk_n,
+  output wire q
+);
+
+  wire clk;
+  IBUFDS ibufds
+  (
+    .I  (sys_clk_p),
+    .IB (sys_clk_n),
+    .O  (clk)
+  );
+
+  blinky #(
+    .clk_freq_hz(200_000_000)
+  ) blinky (
+    .clk (clk),
+    .q   (q)
+  );
+
+endmodule

--- a/blinky.core
+++ b/blinky.core
@@ -6,7 +6,7 @@ filesets:
     files:
       - a_c4e6e10/blinky_a_c4e6e10.sv : {file_type : systemVerilogSource}
       - a_c4e6e10/a_c4e6e10.tcl : {file_type : tclSource}
-      
+
   ac701:
     files:
       - ac701/blinky_ac701.v : {file_type : verilogSource}
@@ -41,6 +41,11 @@ filesets:
 
   alhambra_II:
     files: [alhambra_II/pinout.pcf : {file_type : PCF}]
+
+  alinx_ax7a200b:
+    files:
+      - alinx_ax7a200b/blinky_alinx_ax7a200b.v : {file_type : verilogSource}
+      - alinx_ax7a200b/blinky.xdc : {file_type : xdc}
 
   AnalogMax:
     files:
@@ -610,6 +615,15 @@ targets:
         pnr : next
     toplevel : blinky
 
+  alinx_ax7a200b:
+    default_tool: vivado
+    description : Alinx AX7A200B Development Board
+    filesets : [rtl, alinx_ax7a200b]
+    tools:
+      vivado:
+        part : xc7a200t-fbg484-2
+    toplevel : blinky_alinx_ax7a200b
+
   AnalogMax:
     default_tool : quartus
     filesets : [rtl, AnalogMax]
@@ -720,7 +734,7 @@ targets:
     flow_options:
       part: xcku5p-ffvb676-2-i
     parameters: [clk_freq_hz=200_000_000]
-    toplevel: blinky_axku5  
+    toplevel: blinky_axku5
 
   basys3:
     default_tool : vivado
@@ -1801,7 +1815,7 @@ scripts:
     cmd : [python3, proginfo.py, dfu-util]
   dfu-util-fomu:
     cmd : [python3, proginfo.py, dfu-util-fomu]
-  quartus-OFL: 
+  quartus-OFL:
     cmd : [python3, proginfo.py, quartus-OFL]
   jbc:
     cmd : [quartus_jbcc, "-n", fusesoc_utils_blinky_1_1_1_pof.jam, fusesoc_utils_blinky_1_1_1_pof.jbc]


### PR DESCRIPTION
The board has differential clock input, so a conversion top-level module is needed to produce the single-sided clock input.

The board provides a 200MHz differential general clock signal which is used in the example.

This is similar to the ac701, and the files for this Alinx board were made by adapting the ac701 example.

The pin locations come from the Alinx AX7A200B board documentation.

The "B" in the board name seems to denote the "B" board revision. Inspecting the documentation, it is not obvious to me that the revision "A" (if one indeed exists) would need any changes.